### PR TITLE
Feat: 커뮤니티 페이지에서 댓글 기능 구현

### DIFF
--- a/src/main/java/com/allinone/DevView/community/controller/CommentsController.java
+++ b/src/main/java/com/allinone/DevView/community/controller/CommentsController.java
@@ -1,0 +1,85 @@
+package com.allinone.DevView.community.controller;
+
+import com.allinone.DevView.community.dto.CommentsDto;
+import com.allinone.DevView.community.service.CommentsService;
+import com.allinone.DevView.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/community/posts/{postId}/comments")
+public class CommentsController {
+
+    private final CommentsService commentsService;
+
+    private Long getUserId(CustomUserDetails auth) { return (auth != null) ? auth.getUserId() : null; }
+    private String getWriterName(CustomUserDetails auth) { return (auth != null) ? auth.getUsername() : "익명"; }
+
+    @GetMapping
+    public Page<CommentsDto.Res> list(
+            @PathVariable Long postId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal CustomUserDetails auth
+    ) {
+        int pageSize = Math.min(Math.max(size, 1), 50);
+        Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Long me = getUserId(auth);
+        return commentsService.list(postId, me, pageable);
+    }
+
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public Long create(
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentsDto.CreateReq req,
+            @AuthenticationPrincipal CustomUserDetails auth
+    ) {
+        Long me = getUserId(auth);
+        if (me == null) throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        String writerName = getWriterName(auth);
+        return commentsService.create(postId, me, writerName, req);
+    }
+
+    @PutMapping("/{commentId}")
+    @PreAuthorize("isAuthenticated()")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void update(
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @Valid @RequestBody CommentsDto.UpdateReq req,
+            @AuthenticationPrincipal CustomUserDetails auth
+    ) {
+        Long me = getUserId(auth);
+        if (me == null) throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        try {
+            commentsService.update(commentId, me, req);
+        } catch (SecurityException se) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, se.getMessage());
+        }
+    }
+
+    @DeleteMapping("/{commentId}")
+    @PreAuthorize("isAuthenticated()")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserDetails auth
+    ) {
+        Long me = getUserId(auth);
+        if (me == null) throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        try {
+            commentsService.delete(commentId, me);
+        } catch (SecurityException se) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, se.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/allinone/DevView/community/controller/CommunityController.java
+++ b/src/main/java/com/allinone/DevView/community/controller/CommunityController.java
@@ -1,10 +1,8 @@
 package com.allinone.DevView.community.controller;
 
 import com.allinone.DevView.community.dto.CommunityPostsDto;
-import com.allinone.DevView.community.dto.PostListDto;
-import com.allinone.DevView.community.dto.CommentsDto;
 import com.allinone.DevView.community.dto.CreateInterviewSharePostRequest;
-import com.allinone.DevView.community.entity.Comments;
+import com.allinone.DevView.community.dto.PostListDto;
 import com.allinone.DevView.community.entity.CommunityPosts;
 import com.allinone.DevView.community.entity.Likes;
 import com.allinone.DevView.community.entity.Scraps;
@@ -30,7 +28,6 @@ public class CommunityController {
     private final CommunityQueryService communityQueryService;
     private final CommunityService communityService;
 
-    // 게시글 목록 조회 (댓글 수 포함된 DTO)
     @GetMapping("/posts")
     public ResponseEntity<Page<PostListDto>> listPosts(
             @PageableDefault(page = 0, size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
@@ -44,7 +41,6 @@ public class CommunityController {
         return ResponseEntity.ok(communityService.getAllPostDtos());
     }
 
-    // 단일 게시글 조회
     @GetMapping("/posts/{id}")
     public ResponseEntity<CommunityPosts> getPostById(@PathVariable Long id) {
         return communityService.getPostById(id)
@@ -52,7 +48,6 @@ public class CommunityController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    // 게시글 생성 (기존)
     @PostMapping("/posts")
     public CommunityPosts createPost(@RequestBody CommunityPosts post) {
         return communityService.createPost(post);
@@ -67,67 +62,43 @@ public class CommunityController {
         return ResponseEntity.ok(Map.of("postId", postId));
     }
 
-    // 게시글 수정
     @PutMapping("/posts/{id}")
     public CommunityPosts updatePost(@PathVariable Long id, @RequestBody CommunityPosts post) {
         return communityService.updatePost(id, post);
     }
 
-    // 게시글 삭제
     @DeleteMapping("/posts/{id}")
     public ResponseEntity<Void> deletePost(@PathVariable Long id) {
         communityService.deletePost(id);
         return ResponseEntity.noContent().build();
     }
 
-    // 댓글 목록 조회
-    @GetMapping("/posts/{postId}/comments")
-    public ResponseEntity<Page<CommentsDto>> getComments(
-            @PathVariable Long postId,
-            @PageableDefault(page = 0, size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
-            Pageable pageable
-    ) {
-        return ResponseEntity.ok(communityQueryService.getComments(postId, pageable));
-    }
-
-    // 댓글 작성
-    @PostMapping("/posts/{postId}/comments")
-    public Comments createComment(@PathVariable Long postId, @RequestBody Comments comment) {
-        comment.setPostId(postId);
-        return communityService.createComment(comment);
-    }
-
-    // 댓글 삭제
-    @DeleteMapping("/comments/{id}")
-    public ResponseEntity<Void> deleteComment(@PathVariable Long id) {
-        communityService.deleteComment(id);
-        return ResponseEntity.noContent().build();
-    }
-
-    // 좋아요 추가
     @PostMapping("/posts/{postId}/likes/{userId}")
     public Likes addLike(@PathVariable Long postId, @PathVariable Long userId) {
         return communityService.addLike(userId, postId);
     }
 
-    // 좋아요 취소
     @DeleteMapping("/posts/{postId}/likes/{userId}")
     public ResponseEntity<Void> removeLike(@PathVariable Long postId, @PathVariable Long userId) {
         communityService.removeLike(userId, postId);
         return ResponseEntity.noContent().build();
     }
 
-    // 스크랩 추가
     @PostMapping("/posts/{postId}/scraps")
     public Scraps addScrap(@PathVariable Long postId, @RequestBody Scraps scrap) {
         scrap.setPostId(postId);
         return communityService.addScrap(scrap);
     }
 
-    // 스크랩 삭제
     @DeleteMapping("/scraps/{id}")
     public ResponseEntity<Void> removeScrap(@PathVariable Long id) {
         communityService.removeScrap(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/posts/{postId}/view")
+    public Map<String, Long> increaseView(@PathVariable Long postId) {
+        long cnt = communityService.increaseViewCount(postId);
+        return Map.of("viewCount", cnt);
     }
 }

--- a/src/main/java/com/allinone/DevView/community/dto/CommentsDto.java
+++ b/src/main/java/com/allinone/DevView/community/dto/CommentsDto.java
@@ -1,6 +1,7 @@
 package com.allinone.DevView.community.dto;
 
-import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -8,16 +9,75 @@ import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 public class CommentsDto {
 
-    private Long id;
-
-    private Long userId;
-
+    private Long commentId;
     private Long postId;
-
+    private Long userId;
     private String content;
-
     private LocalDateTime createdAt;
+
+    public CommentsDto(Long commentId, Long postId, Long userId, String content, LocalDateTime createdAt) {
+        this.commentId = commentId;
+        this.postId = postId;
+        this.userId = userId;
+        this.content = content;
+        this.createdAt = createdAt;
+    }
+
+    public static CommentsDto fromEntity(com.allinone.DevView.community.entity.Comments c) {
+        return new CommentsDto(
+                c.getId(),
+                c.getPostId(),
+                c.getUserId(),
+                c.getContent(),
+                c.getCreatedAt()
+        );
+    }
+
+    @Data
+    @NoArgsConstructor
+    public static class CreateReq {
+        private Long parentId;
+
+        @NotBlank
+        @Size(max = 2000)
+        private String content;
+    }
+
+    @Data
+    @NoArgsConstructor
+    public static class UpdateReq {
+        @NotBlank
+        @Size(max = 2000)
+        private String content;
+    }
+
+    @Data
+    @NoArgsConstructor
+    public static class Res {
+        private Long id;
+        private Long userId;
+        private String writerName;
+        private String content;
+        private LocalDateTime createdAt;
+
+        public Res(Long id, Long userId, String writerName, String content, LocalDateTime createdAt) {
+            this.id = id;
+            this.userId = userId;
+            this.writerName = writerName;
+            this.content = content;
+            this.createdAt = createdAt;
+        }
+
+        public static Res fromEntity(com.allinone.DevView.community.entity.Comments c, boolean mine) {
+            return new Res(
+                    c.getId(),
+                    c.getUserId(),
+                    c.getWriterName(),
+                    c.getContent(),
+                    c.getCreatedAt()
+            );
+        }
+    }
 }

--- a/src/main/java/com/allinone/DevView/community/entity/Comments.java
+++ b/src/main/java/com/allinone/DevView/community/entity/Comments.java
@@ -1,14 +1,25 @@
 package com.allinone.DevView.community.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "Comments")
+@Table(
+        name = "Comments",
+        indexes = {
+                @Index(name = "idx_comments_post_id_created_at", columnList = "post_id, created_at DESC"),
+                @Index(name = "idx_comments_user_id", columnList = "user_id"),
+                @Index(name = "idx_comments_parent_id", columnList = "parent_id")
+        }
+)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -25,14 +36,32 @@ public class Comments {
     @Column(name = "post_id", nullable = false)
     private Long postId;
 
-    @Column(name = "content", columnDefinition = "TEXT")
+    @Column(name = "parent_id")
+    private Long parentId;
+
+    @Column(name = "writer_name")
+    private String writerName;
+
+    @NotBlank(message = "댓글 내용을 입력하세요.")
+    @Size(max = 2000, message = "댓글은 최대 2000자까지 가능합니다.")
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    @Column(name = "created_at")
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted", nullable = false)
+    private boolean deleted = false;
+
+    public void edit(String newContent) {
+        this.content = newContent;
+    }
+    public void softDelete() {
+        this.deleted = true;
     }
 }

--- a/src/main/java/com/allinone/DevView/community/repository/CommentsRepository.java
+++ b/src/main/java/com/allinone/DevView/community/repository/CommentsRepository.java
@@ -3,7 +3,10 @@ package com.allinone.DevView.community.repository;
 import com.allinone.DevView.community.entity.Comments;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,10 +14,24 @@ import java.util.List;
 @Repository
 public interface CommentsRepository extends JpaRepository<Comments, Long> {
 
-    List<Comments> findByPostIdOrderByCreatedAtAsc(Long postId);
+    Page<Comments> findByPostIdAndDeletedFalseOrderByCreatedAtDesc(Long postId, Pageable pageable);
+    Slice<Comments> findSliceByPostIdAndDeletedFalseOrderByCreatedAtDesc(Long postId, Pageable pageable);
+    List<Comments> findByParentIdAndDeletedFalseOrderByCreatedAtAsc(Long parentId);
+    Page<Comments> findByUserIdAndDeletedFalseOrderByCreatedAtDesc(Long userId, Pageable pageable);
+    long countByPostIdAndDeletedFalse(Long postId);
+    boolean existsByIdAndUserIdAndDeletedFalse(Long id, Long userId);
 
-    List<Comments> findByUserId(Long userId);
+    @Deprecated
+    @Query("SELECT c FROM Comments c WHERE c.postId = :postId AND c.deleted = false ORDER BY c.createdAt DESC")
+    Page<Comments> findByPostId(@Param("postId") Long postId, Pageable pageable);
 
-    Page<Comments> findByPostId(Long postId, Pageable pageable);
+    @Deprecated
+    @Query("SELECT c FROM Comments c WHERE c.postId = :postId AND c.deleted = false ORDER BY c.createdAt ASC")
+    List<Comments> findByPostIdOrderByCreatedAtAsc(@Param("postId") Long postId);
 
+    @Deprecated
+    @Query("SELECT c FROM Comments c WHERE c.userId = :userId AND c.deleted = false ORDER BY c.createdAt DESC")
+    List<Comments> findByUserId(@Param("userId") Long userId);
+
+    Page<Comments> findByPostIdAndDeletedFalse(Long postId, Pageable pageable);
 }

--- a/src/main/java/com/allinone/DevView/community/service/CommentsService.java
+++ b/src/main/java/com/allinone/DevView/community/service/CommentsService.java
@@ -1,0 +1,63 @@
+package com.allinone.DevView.community.service;
+
+import com.allinone.DevView.community.dto.CommentsDto;
+import com.allinone.DevView.community.entity.Comments;
+import com.allinone.DevView.community.repository.CommentsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentsService {
+
+    private final CommentsRepository commentsRepository;
+
+    @Transactional
+    public Long create(Long postId, Long userId, String writerName, CommentsDto.CreateReq req) {
+        Comments c = new Comments();
+        c.setPostId(postId);
+        c.setUserId(userId);
+        c.setWriterName(writerName);
+        c.setParentId(req.getParentId());
+        c.setContent(req.getContent());
+        c.setDeleted(false);
+        commentsRepository.save(c);
+        return c.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CommentsDto.Res> list(Long postId, Long meUserId, Pageable pageable) {
+        Page<Comments> page = commentsRepository
+                .findByPostIdAndDeletedFalseOrderByCreatedAtDesc(postId, pageable);
+
+        return page.map(c -> new CommentsDto.Res(
+                c.getId(),
+                c.getUserId(),
+                c.getWriterName(),
+                c.getContent(),
+                c.getCreatedAt()
+        ));
+    }
+
+    @Transactional
+    public void update(Long commentId, Long meUserId, CommentsDto.UpdateReq req) {
+        Comments c = commentsRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다. id=" + commentId));
+        if (!c.getUserId().equals(meUserId)) {
+            throw new SecurityException("본인 댓글만 수정할 수 있습니다.");
+        }
+        c.edit(req.getContent());
+    }
+
+    @Transactional
+    public void delete(Long commentId, Long meUserId) {
+        Comments c = commentsRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다. id=" + commentId));
+        if (!c.getUserId().equals(meUserId)) {
+            throw new SecurityException("본인 댓글만 삭제할 수 있습니다.");
+        }
+        c.softDelete();
+    }
+}

--- a/src/main/java/com/allinone/DevView/community/service/CommunityQueryService.java
+++ b/src/main/java/com/allinone/DevView/community/service/CommunityQueryService.java
@@ -41,7 +41,7 @@ public class CommunityQueryService {
     /* 특정 게시글의 댓글 목록 */
     public Page<CommentsDto> getComments(Long postId, Pageable pageable) {
         Pageable safe = sanitizePageable(pageable, "createdAt", Sort.Direction.DESC, COMMENT_SORT_WHITELIST);
-        return commentsRepository.findByPostId(postId, safe)
+        return commentsRepository.findByPostIdAndDeletedFalse(postId, safe)
                 .map(this::toCommentDto);
     }
 

--- a/src/main/java/com/allinone/DevView/community/service/CommunityService.java
+++ b/src/main/java/com/allinone/DevView/community/service/CommunityService.java
@@ -200,8 +200,9 @@ public class CommunityService {
     }
 
     @Transactional
-    public void increaseViewCount(Long postId) {
+    public long increaseViewCount(Long postId) {
         postsRepository.incrementViewCount(postId);
+        return 0;
     }
 
     public List<Likes> getLikesByUserId(Long userId) {

--- a/src/main/resources/static/css/community.css
+++ b/src/main/resources/static/css/community.css
@@ -322,3 +322,13 @@ html, body {
   }
 }
 .is-readonly { opacity: 0.6; cursor: default; }
+
+.comments-section { margin-top: 24px; }
+.comment-form { display: grid; gap: 8px; }
+.comment-form textarea { width: 100%; min-height: 80px; padding: 8px; }
+.comment-actions { text-align: right; }
+.comment-list { display: grid; gap: 16px; margin-top: 12px; }
+.comment-item { border: 1px solid #e5e7eb; border-radius: 8px; padding: 12px; }
+.comment-item .meta { font-size: 0.9rem; color: #6b7280; display:flex; gap:8px; }
+.comment-item .content { margin-top: 6px; white-space: pre-wrap; }
+.comment-item .actions { margin-top: 8px; display:flex; gap:8px; }

--- a/src/main/resources/static/css/post-detail.css
+++ b/src/main/resources/static/css/post-detail.css
@@ -4,8 +4,17 @@ html, body {
   background: #FFFFFF;
   color: #2d3a4a;
 }
-
 * { box-sizing: border-box; }
+
+:root{
+  --ink:#2d3a4a;
+  --muted:#6b7a8c;
+  --line:#e8edf3;
+  --soft:#f7f9fc;
+  --brand:#3b82f6;
+  --like:#e74c3c;
+  --scrap:#4a90e2;
+}
 
 .main-container {
   max-width: 960px;
@@ -24,11 +33,7 @@ html, body {
   gap: 14px;
 }
 
-.post-header {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
+.post-header { display: flex; align-items: center; gap: 12px; }
 
 .profile-img {
   width: 36px;
@@ -39,7 +44,6 @@ html, body {
 }
 
 .user-info { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-
 .username { font-weight: 700; color: #253243; }
 
 .user-role {
@@ -80,89 +84,39 @@ html, body {
   background: #f5f7fa;
 }
 
-.badge-tech {
-  background: #eaf2ff;
-  border-color: #cfe3ff;
-  color: #235ea6;
-}
-
-.score {
-  padding: 6px 10px;
-  border-radius: 10px;
-  background: #e9f7ef;
-  border: 1px solid #cfe9db;
-  color: #0f5132;
-}
-
+.badge-tech { background: #eaf2ff; border-color: #cfe3ff; color: #235ea6; }
+.score { padding: 6px 10px; border-radius: 10px; background: #e9f7ef; border: 1px solid #cfe9db; color: #0f5132; }
 .grade { color: #667789; }
 
-.post-summary,
-.post-content {
+.post-summary, .post-content {
   color: #374b5f;
   font-size: 16px;
   line-height: 1.7;
   word-break: break-word;
 }
-
 .post-content p { margin: 0 0 14px; }
 .post-content img { max-width: 100%; height: auto; border-radius: 8px; }
 
 .post-footer {
   display: flex;
-  align-items: center;
-  gap: 16px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
   color: #738399;
   font-size: 14px;
   border-top: 1px solid #eef2f6;
   padding-top: 10px;
 }
 
-.post-footer i { margin-right: 6px; opacity: .9; }
-
-.read-more {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  height: 40px;
-  padding: 0 12px;
-  border-radius: 10px;
-  border: 1px solid #e5ebf2;
-  background: #fff;
-  color: #2b6cb0;
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.read-more:hover { background: #e8f2ff; }
-
-@media (max-width: 640px) {
-  .main-container { padding: 16px 12px 40px; }
-  .post-title { font-size: 20px; }
-  .post-detail-card { padding: 16px; border-radius: 12px; }
-}
-/* 메트릭 바 */
-.post-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  margin-top: 16px;
-}
-
 .metrics {
   display: inline-flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 14px;
   color: #6b7c93;
   font-size: 14px;
 }
-
-.metric {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
+.metric { display: inline-flex; align-items: center; gap: 6px; }
 
 .btn-icon {
   appearance: none;
@@ -171,15 +125,110 @@ html, body {
   padding: 0;
   cursor: pointer;
   color: inherit;
+  display:inline-flex; align-items:center; gap:6px;
+  transition: transform .06s ease, opacity .2s ease, filter .2s ease;
 }
-
-.btn-icon:hover i {
-  filter: brightness(0.85);
-}
-
-.btn-like.active i { color: #e74c3c; }     /* 빨간 하트 */
-.btn-scrap.active i { color: #4a90e2; }    /* 파란 북마크 */
+.btn-icon:hover i { filter: brightness(0.9); }
+.btn-icon:active { transform: translateY(1px); }
+.btn-icon, .btn-icon:focus { outline: none; box-shadow: none; }
 
 .metric .count { display: inline-block; min-width: 10px; }
 
-.btn-icon, .btn-icon:focus { outline: none; box-shadow: none; }
+
+.btn-like i::before { content: "\f004"; }       /* fa-heart */
+.btn-scrap i::before { content: "\f02e"; }      /* fa-bookmark */
+.btn-like i, .btn-scrap i { font-family: "Font Awesome 6 Free"; font-weight: 900; }
+
+
+.btn-like i, .btn-scrap i {
+  color: #9aa7b5;
+}
+
+
+.btn-like.active i { color: var(--like); }
+.btn-scrap.active i { color: var(--scrap); }
+.btn-like.active i, .btn-scrap.active i { transform: scale(1.02); }
+
+/* divider */
+.meta-divider { border: 0; border-top: 1px solid #e5e7eb; margin: 6px 0 0; }
+
+.comments-section { margin-top: 12px; width: 100%; clear: both; }
+
+.comments {
+  margin-top: 16px;
+  border-top: 1px solid var(--line);
+  padding-top: 16px;
+}
+
+.comments__title{
+  display:flex; align-items:center; gap:8px;
+  font-size:16px; font-weight:700; color:var(--ink); margin-bottom:12px;
+}
+.comments__badge{
+  font-size:12px; color:var(--muted);
+  background:var(--soft); border:1px solid var(--line);
+  padding:2px 8px; border-radius:999px;
+}
+
+.comment-form{
+  display:flex; gap:10px; align-items:flex-end;
+  background:#fff; border:1px solid var(--line); border-radius:12px;
+  padding:10px; box-shadow:0 4px 12px rgba(27,39,51,.04);
+  margin-bottom:14px;
+}
+.comment-form textarea{
+  flex:1; resize:vertical; min-height:44px; max-height:180px;
+  border:none; outline:none; font-size:14px; color:var(--ink);
+}
+.comment-form textarea::placeholder{ color:#a8b3c2; }
+
+.comment-form .btn-submit{
+  white-space:nowrap; padding:10px 14px; border-radius:10px;
+  border:1px solid var(--brand); background:var(--brand); color:#fff;
+  font-weight:600; cursor:pointer; transition:transform .06s ease, box-shadow .2s ease, opacity .2s;
+  box-shadow:0 6px 14px rgba(59,130,246,.18);
+}
+.comment-form .btn-submit:hover{ transform:translateY(-1px); }
+.comment-form .btn-submit:disabled{
+  opacity:.5; cursor:not-allowed; box-shadow:none; transform:none;
+}
+.comment-form:focus-within{
+  border-color:var(--brand);
+  box-shadow:0 0 0 3px rgba(59,130,246,.12), 0 6px 16px rgba(27,39,51,.06);
+}
+
+.comment-list{ display:flex; flex-direction:column; gap:10px; }
+
+.comment-item{
+  display:grid; grid-template-columns:36px 1fr; gap:10px;
+  padding:10px 10px; border:1px solid var(--line);
+  background:#fff; border-radius:12px;
+}
+.comment-item__avatar{
+  width:36px; height:36px; border-radius:50%; object-fit:cover;
+  border:1px solid #e6edf5; background:#eef3f9;
+}
+.comment-item__head{ display:flex; align-items:center; gap:8px; margin-bottom:4px; }
+.comment-item__author{ font-weight:700; color:var(--ink); font-size:14px; }
+.comment-item__meta{ font-size:12px; color:var(--muted); }
+.comment-item__body{ font-size:14px; line-height:1.6; color:var(--ink); word-break:break-word; }
+
+.comment-item__actions{ margin-top:6px; display:flex; gap:8px; }
+.comment-action{
+  font-size:12px; color:var(--muted); padding:4px 8px;
+  border:1px solid var(--line); border-radius:8px; background:var(--soft);
+  cursor:pointer;
+}
+.comment-action--danger{ color:#c73a3a; border-color:#ffd9d9; background:#fff5f5; }
+
+/* 반응형 */
+@media (max-width: 640px){
+  .main-container { padding: 16px 12px 40px; }
+  .post-title { font-size: 20px; }
+  .post-detail-card { padding: 16px; border-radius: 12px; }
+
+  .comment-item{ grid-template-columns:28px 1fr; }
+  .comment-item__avatar{ width:28px; height:28px; }
+  .comment-form{ padding:8px; }
+  .comment-form .btn-submit{ padding:8px 12px; }
+}

--- a/src/main/resources/static/js/post-detail-comments.js
+++ b/src/main/resources/static/js/post-detail-comments.js
@@ -1,0 +1,287 @@
+'use strict';
+
+function __getCsrf__() {
+  const t = document.querySelector('meta[name="_csrf"]')?.content;
+  const h = document.querySelector('meta[name="_csrf_header"]')?.content;
+  if (t && h) return { header: h, token: t };
+  const m = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]+)/);
+  if (m) return { header: 'X-XSRF-TOKEN', token: decodeURIComponent(m[1]) };
+  return { header: null, token: null };
+}
+function __secureHeaders__(json = true) {
+  const { header, token } = __getCsrf__();
+  const h = { 'X-Requested-With': 'XMLHttpRequest' };
+  if (json) h['Content-Type'] = 'application/json';
+  if (header && token) h[header] = token;
+  return h;
+}
+
+(function () {
+  const POST_ID = window.POST_ID;
+  const LIST   = document.getElementById('comment-list');
+  const MORE   = document.getElementById('comment-load-more');
+  const INPUT  = document.getElementById('comment-input');
+  const SUBMIT = document.getElementById('comment-submit');
+  if (!POST_ID || !LIST) return;
+
+  let page = 0, size = 10, last = false;
+  let busy = false;
+
+  function esc(s){
+    return (s||'').replace(/[&<>"']/g,ch=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
+  }
+  function handleAuthFailure(res){
+    if(res.status===401){ alert('로그인이 필요합니다.'); location.href='/login'; return true; }
+    if(res.status===403){ alert('요청이 거부되었습니다. 다시 시도해 주세요.'); return true; }
+    return false;
+  }
+  function resetAndReload() {
+    page = 0;
+    last = false;
+    LIST.innerHTML = '';
+    fetchList();
+  }
+
+  function isMine(c){
+    const uid = window.CURRENT_USER_ID ?? window.currentUserId;
+    const uem = window.CURRENT_USER_EMAIL ?? window.currentUserEmail;
+    const uname = window.CURRENT_USERNAME ?? window.currentUsername;
+    if (uid != null && c.userId != null && String(uid) === String(c.userId)) return true;
+    if (uem && c.writerName && String(uem).toLowerCase() === String(c.writerName).toLowerCase()) return true;
+    if (uname && c.writerName && String(uname) === String(c.writerName)) return true;
+    return !!c.mine;
+  }
+  const enrichComment = (c)=>({ ...c, mine: isMine(c) });
+
+  async function fetchList(){
+    if(last||busy) return; busy=true;
+    try{
+      const res = await fetch(`/api/community/posts/${POST_ID}/comments?page=${page}&size=${size}`,{
+        credentials:'same-origin',
+        headers:__secureHeaders__(false)
+      });
+      if(!res.ok){ if(handleAuthFailure(res))return; return; }
+      const data = await res.json();
+      (data.content||[]).map(enrichComment).forEach(c => renderItem(c));
+      last = !!data.last;
+      if(!last){ MORE && (MORE.style.display='block'); page++; }
+      else { MORE && (MORE.style.display='none'); }
+    } finally { busy=false; }
+  }
+
+  function renderItem(c, opts = {}) {
+    const id = c.id ?? c.commentId;
+    if (id && LIST.querySelector(`.comment-item[data-id="${id}"]`)) return;
+
+    const li=document.createElement('li');
+    li.className='comment-item';
+    li.dataset.id=id;
+    const author=esc(c.writerName || (c.userId!=null?('user#'+c.userId):'익명'));
+    const time=c.createdAt? new Date(c.createdAt).toLocaleString() : '';
+    li.innerHTML=`
+      <img class="comment-item__avatar" src="/img/profile-default.svg" alt="프로필">
+      <div class="comment-item__main">
+        <div class="comment-item__head">
+          <span class="comment-item__author">${author}</span>
+          <span class="comment-item__meta">${esc(time)}</span>
+        </div>
+        <div class="comment-item__body" data-view>${esc(c.content)}</div>
+        <div class="comment-item__actions" data-actions>
+          ${isMine(c)?`
+            <button class="comment-action edit" type="button">수정</button>
+            <button class="comment-action comment-action--danger delete" type="button">삭제</button>
+          `:''}
+        </div>
+      </div>`;
+    if (opts.prepend) LIST.prepend(li); else LIST.appendChild(li);
+  }
+
+  function cancelAnyEditing() {
+    const opened = LIST.querySelector('.comment-item[data-editing="true"]');
+    if (!opened) return;
+    exitEdit(opened, /*restore*/true);
+  }
+
+  function enterEdit(item){
+    if(item.dataset.editing === 'true') return;
+    cancelAnyEditing();
+
+    const body = item.querySelector('[data-view]');
+    const actions = item.querySelector('[data-actions]');
+    const prev = body.textContent;
+
+    const ta = document.createElement('textarea');
+    ta.className = 'comment-edit-textarea';
+    ta.value = prev;
+    ta.maxLength = 2000;
+    ta.rows = Math.min(6, Math.max(2, prev.split('\n').length));
+    body.style.display = 'none';
+    body.after(ta);
+
+    const saveBtn  = document.createElement('button');
+    const cancelBtn= document.createElement('button');
+    saveBtn.type='button'; cancelBtn.type='button';
+    saveBtn.className='comment-action save';
+    cancelBtn.className='comment-action cancel';
+    saveBtn.textContent='저장';
+    cancelBtn.textContent='취소';
+    const editBtn = actions.querySelector('.edit'); if (editBtn) editBtn.style.display='none';
+    actions.prepend(cancelBtn);
+    actions.prepend(saveBtn);
+
+    const keyHandler = (e)=>{
+      if(e.key==='Escape'){ exitEdit(item, true); }
+      if(e.key==='Enter' && (e.ctrlKey||e.metaKey)){ saveEdit(item); }
+    };
+    ta.addEventListener('keydown', keyHandler);
+    item._edit = { ta, saveBtn, cancelBtn, keyHandler, prevText: prev };
+    item.dataset.editing = 'true';
+    ta.focus();
+  }
+
+  async function saveEdit(item){
+    const ctx = item._edit; if(!ctx) return;
+    const id = item.dataset.id;
+    const next = (ctx.ta.value||'').trim();
+    if(!next){ alert('내용을 입력하세요.'); return; }
+    if(next.length>2000){ alert('댓글은 최대 2000자까지 가능합니다.'); return; }
+
+    try{
+      const res=await fetch(`/api/community/posts/${POST_ID}/comments/${id}`,{
+        method:'PUT', headers:__secureHeaders__(true), credentials:'same-origin',
+        body:JSON.stringify({ content: next })
+      });
+      if(!res.ok){ if(handleAuthFailure(res))return; alert('수정에 실패했습니다.'); return; }
+      const body = item.querySelector('[data-view]');
+      body.textContent = next;
+      exitEdit(item, /*restore*/false);
+    }catch{
+      alert('수정 중 오류가 발생했습니다.');
+    }
+  }
+
+  function exitEdit(item, restore){
+    const ctx = item._edit; if(!ctx) return;
+    const body = item.querySelector('[data-view]');
+    body.style.display = '';
+    if (restore) body.textContent = ctx.prevText;
+
+    ctx.ta.remove();
+    ctx.saveBtn.remove();
+    ctx.cancelBtn.remove();
+    const actions = item.querySelector('[data-actions]');
+    const editBtn = actions.querySelector('.edit'); if (editBtn) editBtn.style.display='';
+    item.dataset.editing = 'false';
+    item._edit = null;
+  }
+
+  async function createComment(){
+    if(!window.IS_AUTH){ alert('로그인이 필요합니다.'); return; }
+    const content=(INPUT?.value||'').trim();
+    if(!content) return;
+    if(content.length>2000){ alert('댓글은 최대 2000자까지 가능합니다.'); return; }
+    if(busy) return;
+
+    busy=true; SUBMIT && (SUBMIT.disabled=true);
+    try{
+      const payload = { postId: POST_ID, content, parentId: null, writerName: window.CURRENT_USERNAME || window.CURRENT_USER_EMAIL || null };
+      const res=await fetch(`/api/community/posts/${POST_ID}/comments`,{
+        method:'POST', headers:__secureHeaders__(true), credentials:'same-origin',
+        body:JSON.stringify(payload)
+      });
+      if(!res.ok){ if(handleAuthFailure(res))return; alert('댓글 등록에 실패했습니다.'); return; }
+      INPUT.value='';
+      resetAndReload();
+    } finally { busy=false; SUBMIT && (SUBMIT.disabled=false); }
+  }
+
+  LIST?.addEventListener('click', async (e)=>{
+    const btn=e.target.closest('button'); if(!btn) return;
+    const item=e.target.closest('.comment-item'); if(!item) return;
+    const id=item.dataset.id;
+
+    if(btn.classList.contains('delete')){
+      if(!confirm('이 댓글을 삭제할까요?')) return;
+      try{
+        const res=await fetch(`/api/community/posts/${POST_ID}/comments/${id}`,{
+          method:'DELETE', headers:__secureHeaders__(false), credentials:'same-origin'
+        });
+        if(!res.ok){ if(handleAuthFailure(res))return; alert('삭제에 실패했습니다.'); return; }
+        item.remove();
+      }catch{ alert('삭제 중 오류가 발생했습니다.'); }
+      return;
+    }
+
+    if(btn.classList.contains('edit')){
+      enterEdit(item);
+      return;
+    }
+
+    if(btn.classList.contains('save')){
+      await saveEdit(item);
+      return;
+    }
+
+    if(btn.classList.contains('cancel')){
+      exitEdit(item, /*restore*/true);
+      return;
+    }
+  });
+
+  MORE?.addEventListener('click', fetchList);
+  const keyHandler=(e)=>{ if(e.isComposing) return; if(e.key==='Enter'&&!e.shiftKey){ e.preventDefault(); createComment(); } };
+  INPUT?.addEventListener('keydown', keyHandler);
+  SUBMIT?.addEventListener('click', createComment);
+
+  fetchList();
+})();
+
+document.addEventListener('click', async (e)=>{
+  const likeBtn = e.target.closest('.btn-like');
+  const scrapBtn = e.target.closest('.btn-scrap');
+
+  const toggle = async (btn)=>{
+    const url = btn.dataset.url;
+    if(!url) return;
+    try{
+      const res = await fetch(url,{ method:'POST', headers:__secureHeaders__(false), credentials:'same-origin' });
+      if(!res.ok) throw new Error();
+      const data = await res.json();
+      const active = !!data.active;
+      btn.classList.toggle('active', active);
+      const icon = btn.querySelector('i');
+      if(icon){
+        icon.classList.toggle('fa-solid', active);
+        icon.classList.toggle('fa-regular', !active);
+      }
+      btn.querySelector('.count').textContent = data.count;
+    }catch{
+      const active = btn.classList.toggle('active');
+      const span = btn.querySelector('.count');
+      const cur = parseInt(span.textContent||'0',10);
+      span.textContent = Math.max(0, cur + (active?1:-1));
+      const icon = btn.querySelector('i');
+      if(icon){
+        icon.classList.toggle('fa-solid', active);
+        icon.classList.toggle('fa-regular', !active);
+      }
+    }
+  };
+
+  if(likeBtn)  await toggle(likeBtn);
+  if(scrapBtn) await toggle(scrapBtn);
+});
+
+if(window.POST_ID){
+  fetch(`/api/community/posts/${window.POST_ID}/view`,{
+    method:'POST', credentials:'same-origin', headers:__secureHeaders__(false)
+  })
+  .then(r=>r.ok?r.json():null)
+  .then(d=>{
+    if(d?.viewCount!=null){
+      const el=document.getElementById('view-count');
+      if(el) el.textContent=d.viewCount;
+    }
+  })
+  .catch(()=>{});
+}

--- a/src/main/resources/templates/community/post-detail.html
+++ b/src/main/resources/templates/community/post-detail.html
@@ -1,8 +1,11 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<html lang="ko"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
     <meta charset="UTF-8" />
     <title th:text="${post.title} + ' - 게시글 상세보기'">게시글 상세보기</title>
+
     <link rel="stylesheet" href="/css/header.css">
     <link rel="stylesheet" href="/css/post-detail.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
@@ -11,76 +14,91 @@
     <meta name="_csrf_header" th:content="${_csrf.headerName}">
 
     <script th:inline="javascript">
-        /*<![CDATA[*/
-        window.CURRENT_USER_ID = /*[[${session.userId}]]*/ null;
-        /*]]>*/
+        window.IS_AUTH  = [[${#authorization.expression('isAuthenticated()')}]];
+        window.POST_ID  = [[${post.id}]];
+        window.CURRENT_USERNAME = [[${#authentication} != null ? ${#authentication.name} : null]];
     </script>
 </head>
+
 <body data-page="detail">
 <div th:replace="~{fragments/header :: header}"></div>
 
 <main class="main-container">
-    <div class="post-detail-card" th:data-post-id="${post.id}">
+    <div class="post-detail-card" th:attr="data-post-id=${post.id}">
+
         <header class="post-header">
             <img class="profile-img" th:src="@{/img/profile-default.svg}" alt="프로필" />
             <div class="user-info">
-                <span class="username" th:text="${post.username}">김개발</span>
+                <span class="username" th:text="${post.username}">testuser</span>
                 <span class="post-date"
                       th:text="${post.createdAt != null ? #temporals.format(post.createdAt, 'yyyy-MM-dd') : ''}">
-          2025-08-08
-        </span>
+            2025-08-08
+          </span>
             </div>
         </header>
 
-        <h2 class="post-title" th:text="${post.title}">Spring Boot 마이크로서비스 아키텍처 설계 면접 후기</h2>
+        <h2 class="post-title" th:text="${post.title}">게시글 제목</h2>
 
         <div class="badges">
-            <span class="badge badge-tech" th:text="${post.interviewType}">기술면접</span>
-            <span class="score" th:text="${post.score} + ' 점'">88 점</span>
-            <span class="grade" th:text="'• ' + ${post.grade} + ' 등급'">• B 등급</span>
+            <span class="badge badge-tech" th:text="${post.interviewType}">PRACTICE</span>
+            <span class="score" th:text="${post.score} + ' 점'">0 점</span>
+            <span class="grade" th:text="'• ' + ${post.grade} + ' 등급'">• C 등급</span>
         </div>
 
         <div class="post-content" th:text="${post.summary}">
-            면접에서 MSA 패턴과 API Gateway 설계에 대한 질문이 많이 나왔습니다...
+            게시글 요약/내용
         </div>
 
-        <footer class="post-footer">
-            <div class="metrics" th:data-post-id="${post.id}">
-    <span class="metric">
-      <i class="fas fa-eye"></i>
-      <span class="count" th:text="${post.viewCount}">0</span>
-    </span>
+        <div class="post-footer">
+            <div class="metrics">
+                <div class="metric">
+                    <i class="fa-solid fa-eye" aria-hidden="true"></i>
+                    <span id="view-count" class="count" th:text="${post.viewCount}">0</span>
+                </div>
 
-                <button type="button"
-                        class="metric btn-icon btn-like"
-                        th:attr="data-post-id=${post.id},data-user-id=${session.userId}"
-                        aria-label="좋아요" aria-pressed="false">
-                    <i class="fas fa-heart"></i>
+                <button type="button" class="btn-icon btn-like"
+                        data-post-id="[[${post.id}]]"
+                        th:data-url="@{/api/community/posts/{id}/like(id=${post.id})}">
+                    <i class="fa-solid fa-heart" aria-hidden="true"></i>
                     <span class="count" th:text="${post.likeCount}">0</span>
                 </button>
 
-                <!-- 댓글은 필요 시
-                <span class="metric">
-                  <i class="fas fa-comment"></i>
-                  <span class="count" th:text="${post.commentCount}">0</span>
-                </span>
-                -->
-
-                <button type="button"
-                        class="metric btn-icon btn-scrap"
-                        th:attr="data-post-id=${post.id},data-user-id=${session.userId}"
-                        aria-label="스크랩" aria-pressed="false">
-                    <i class="fas fa-bookmark"></i>
+                <button type="button" class="btn-icon btn-scrap"
+                        data-post-id="[[${post.id}]]"
+                        th:data-url="@{/api/community/posts/{id}/scrap(id=${post.id})}">
+                    <i class="fa-regular fa-bookmark" aria-hidden="true"></i>
                     <span class="count" th:text="${post.scrapCount}">0</span>
                 </button>
             </div>
+            <hr class="meta-divider" />
+        </div>
 
-            <a class="read-more" href="/community">목록으로</a>
-        </footer>
+        <section class="comments-section">
+            <div class="comments">
+                <div class="comments__title">
+                    <span>댓글</span>
+                    <span class="comments__badge"
+                          th:text="${comments} != null ? ${#lists.size(comments)} + '개' : '0개'">0개</span>
+                </div>
+
+                <form class="comment-form" onsubmit="return false;">
+                    <textarea id="comment-input" name="content" placeholder="댓글을 입력하세요..." required></textarea>
+                    <button id="comment-submit" type="button" class="btn-submit"
+                            th:disabled="${#authorization.expression('!isAuthenticated()')}">등록</button>
+                </form>
+
+                <ul id="comment-list" class="comment-list"></ul>
+                <button id="comment-load-more" type="button" style="display:none">더보기</button>
+            </div>
+        </section>
+
+        <div style="margin-top:16px; display:flex; justify-content:flex-end;">
+            <a class="read-more" th:href="@{/community}">목록으로 가기</a>
+        </div>
 
     </div>
 </main>
 
-<script src="/js/community.js"></script>
+<script th:src="@{/js/post-detail-comments.js}" defer></script>
 </body>
 </html>


### PR DESCRIPTION
feat: 댓글 수정 기능을 팝업 대신 인라인 편집으로 변경

- 기존 prompt 기반 댓글 수정 로직 제거
- 댓글 본문 영역을 textarea로 전환하여 인라인 수정 가능하도록 구현
- 저장/취소 버튼 및 Ctrl+Enter 저장, Esc 취소 단축키 지원
- 수정 시 단일 댓글만 편집 가능하도록 제한
- 저장 성공 시 DOM만 갱신하여 페이지 리로딩 없이 즉시 반영
- 댓글 삭제 및 작성 로직과 함께 동작하도록 이벤트 핸들러 통합
