### PR TITLE
fix: 커뮤니티 댓글 기능 복구 (Reapply #44)

### DIFF
--- a/src/main/java/com/allinone/DevView/community/controller/CommentsController.java
+++ b/src/main/java/com/allinone/DevView/community/controller/CommentsController.java
@@ -37,7 +37,7 @@ public class CommentsController {
 
     @PostMapping
     @PreAuthorize("isAuthenticated()")
-    public Long create(
+    public CommentsDto.Res create(
             @PathVariable Long postId,
             @Valid @RequestBody CommentsDto.CreateReq req,
             @AuthenticationPrincipal CustomUserDetails auth

--- a/src/main/java/com/allinone/DevView/community/dto/CommentsDto.java
+++ b/src/main/java/com/allinone/DevView/community/dto/CommentsDto.java
@@ -58,23 +58,30 @@ public class CommentsDto {
     public static class Res {
         private Long id;
         private Long userId;
+        private String username;
         private String writerName;
         private String content;
         private LocalDateTime createdAt;
+        private boolean mine;
 
-        public Res(Long id, Long userId, String writerName, String content, LocalDateTime createdAt) {
+        public Res(Long id, Long userId, String username, String writerName, String content, LocalDateTime createdAt) {
             this.id = id;
             this.userId = userId;
+            this.username = username;
             this.writerName = writerName;
             this.content = content;
             this.createdAt = createdAt;
         }
 
-        public static Res fromEntity(com.allinone.DevView.community.entity.Comments c, boolean mine) {
+        public static Res of(com.allinone.DevView.community.entity.Comments c, String username) {
+            String display = (username != null && !username.isBlank())
+                    ? username
+                    : c.getWriterName();
             return new Res(
                     c.getId(),
                     c.getUserId(),
-                    c.getWriterName(),
+                    username,
+                    display,
                     c.getContent(),
                     c.getCreatedAt()
             );

--- a/src/main/java/com/allinone/DevView/community/entity/CommunityPosts.java
+++ b/src/main/java/com/allinone/DevView/community/entity/CommunityPosts.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
 
@@ -14,6 +16,8 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @NoArgsConstructor
+@SQLDelete(sql = "UPDATE community_posts SET deleted = true WHERE post_id = ?")
+@Where(clause = "deleted = false")
 public class CommunityPosts {
 
     @Id
@@ -80,6 +84,9 @@ public class CommunityPosts {
 
     @Column(name = "interview_feedback", columnDefinition = "TEXT")
     private String interviewFeedback;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/com/allinone/DevView/community/repository/CommentsRepository.java
+++ b/src/main/java/com/allinone/DevView/community/repository/CommentsRepository.java
@@ -1,6 +1,7 @@
 package com.allinone.DevView.community.repository;
 
 import com.allinone.DevView.community.entity.Comments;
+import com.allinone.DevView.community.entity.CommunityPosts;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -10,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CommentsRepository extends JpaRepository<Comments, Long> {
@@ -34,4 +36,13 @@ public interface CommentsRepository extends JpaRepository<Comments, Long> {
     List<Comments> findByUserId(@Param("userId") Long userId);
 
     Page<Comments> findByPostIdAndDeletedFalse(Long postId, Pageable pageable);
+
+    @Query("SELECT p FROM CommunityPosts p WHERE p.postId = :id AND p.deleted = false")
+    Optional<CommunityPosts> findActiveById(@Param("id") Long id);
+
+    Page<CommunityPosts> findAllByDeletedFalse(Pageable pageable);
+
+    @Query("SELECT p FROM CommunityPosts p WHERE p.postId = :id")
+    Optional<CommunityPosts> findAnyById(@Param("id") Long id);
+
 }

--- a/src/main/java/com/allinone/DevView/community/service/CommentsService.java
+++ b/src/main/java/com/allinone/DevView/community/service/CommentsService.java
@@ -3,51 +3,95 @@ package com.allinone.DevView.community.service;
 import com.allinone.DevView.community.dto.CommentsDto;
 import com.allinone.DevView.community.entity.Comments;
 import com.allinone.DevView.community.repository.CommentsRepository;
+import com.allinone.DevView.user.entity.User;
+import com.allinone.DevView.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class CommentsService {
 
     private final CommentsRepository commentsRepository;
+    private final UserRepository userRepository;
 
     @Transactional
-    public Long create(Long postId, Long userId, String writerName, CommentsDto.CreateReq req) {
+    public CommentsDto.Res create(Long postId, Long userId, String ignoreWriterName, CommentsDto.CreateReq req) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. id=" + userId));
+
         Comments c = new Comments();
         c.setPostId(postId);
         c.setUserId(userId);
-        c.setWriterName(writerName);
+        c.setWriterName(user.getUsername());
         c.setParentId(req.getParentId());
         c.setContent(req.getContent());
         c.setDeleted(false);
-        commentsRepository.save(c);
-        return c.getId();
+
+        Comments saved = commentsRepository.save(c);
+
+        return new CommentsDto.Res(
+                saved.getId(),
+                saved.getUserId(),
+                user.getUsername(),
+                user.getUsername(),
+                saved.getContent(),
+                saved.getCreatedAt()
+        );
     }
 
     @Transactional(readOnly = true)
     public Page<CommentsDto.Res> list(Long postId, Long meUserId, Pageable pageable) {
-        Page<Comments> page = commentsRepository
-                .findByPostIdAndDeletedFalseOrderByCreatedAtDesc(postId, pageable);
 
-        return page.map(c -> new CommentsDto.Res(
-                c.getId(),
-                c.getUserId(),
-                c.getWriterName(),
-                c.getContent(),
-                c.getCreatedAt()
-        ));
+        Page<Comments> page = commentsRepository.findByPostIdAndDeletedFalse(postId, pageable);
+
+        List<Comments> items = page.getContent();
+        if (items.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), pageable, page.getTotalElements());
+        }
+
+        Set<Long> userIds = items.stream()
+                .map(Comments::getUserId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> usernameMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getUserId, User::getUsername));
+
+
+        List<CommentsDto.Res> resList = items.stream()
+                .map(c -> {
+                    String username = usernameMap.getOrDefault(c.getUserId(), c.getWriterName());
+                    return new CommentsDto.Res(
+                            c.getId(),
+                            c.getUserId(),
+                            username,
+                            username,
+                            c.getContent(),
+                            c.getCreatedAt()
+                    );
+                })
+                .toList();
+
+        return new PageImpl<>(resList, pageable, page.getTotalElements());
     }
 
     @Transactional
     public void update(Long commentId, Long meUserId, CommentsDto.UpdateReq req) {
         Comments c = commentsRepository.findById(commentId)
                 .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다. id=" + commentId));
-        if (!c.getUserId().equals(meUserId)) {
+
+        if (!Objects.equals(c.getUserId(), meUserId)) {
             throw new SecurityException("본인 댓글만 수정할 수 있습니다.");
         }
+
         c.edit(req.getContent());
     }
 
@@ -55,9 +99,11 @@ public class CommentsService {
     public void delete(Long commentId, Long meUserId) {
         Comments c = commentsRepository.findById(commentId)
                 .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다. id=" + commentId));
-        if (!c.getUserId().equals(meUserId)) {
+
+        if (!Objects.equals(c.getUserId(), meUserId)) {
             throw new SecurityException("본인 댓글만 삭제할 수 있습니다.");
         }
+
         c.softDelete();
     }
 }

--- a/src/main/java/com/allinone/DevView/community/service/CommunityService.java
+++ b/src/main/java/com/allinone/DevView/community/service/CommunityService.java
@@ -191,7 +191,6 @@ public class CommunityService {
 
     @Transactional
     public CommunityPostDetailDto getPostDetailDto(Long postId) {
-        // 먼저 +1 (clearAutomatically=true로 1차 캐시 갱신)
         postsRepository.incrementViewCount(postId);
 
         CommunityPosts post = postsRepository.findByIdWithUser(postId)

--- a/src/main/resources/static/css/post-detail.css
+++ b/src/main/resources/static/css/post-detail.css
@@ -220,6 +220,32 @@ html, body {
   cursor:pointer;
 }
 .comment-action--danger{ color:#c73a3a; border-color:#ffd9d9; background:#fff5f5; }
+.post-detail__nav{
+  display:flex; justify-content:flex-end;
+  margin-top:24px;
+}
+
+#btn-back-to-list{
+  display:inline-flex; align-items:center; gap:8px;
+  padding:10px 16px; border-radius:12px;
+  background:#fff; color:#2d3a4a; text-decoration:none; font-weight:600;
+  border:1px solid #dbe3f0;
+  transition: border-color .2s, box-shadow .2s, transform .1s;
+}
+
+#btn-back-to-list:hover{
+  border-color:#8fa6ff;
+  box-shadow:0 6px 18px rgba(76, 102, 235, .18);
+  transform: translateY(-1px);
+}
+
+#btn-back-to-list:active{
+  transform: translateY(0);
+}
+
+#btn-back-to-list .fa{
+  font-size:14px;
+}
 
 /* 반응형 */
 @media (max-width: 640px){

--- a/src/main/resources/static/js/post-detail-comments.js
+++ b/src/main/resources/static/js/post-detail-comments.js
@@ -17,271 +17,287 @@ function __secureHeaders__(json = true) {
 }
 
 (function () {
-  const POST_ID = window.POST_ID;
-  const LIST   = document.getElementById('comment-list');
-  const MORE   = document.getElementById('comment-load-more');
-  const INPUT  = document.getElementById('comment-input');
-  const SUBMIT = document.getElementById('comment-submit');
-  if (!POST_ID || !LIST) return;
-
-  let page = 0, size = 10, last = false;
-  let busy = false;
-
-  function esc(s){
-    return (s||'').replace(/[&<>"']/g,ch=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
-  }
-  function handleAuthFailure(res){
-    if(res.status===401){ alert('로그인이 필요합니다.'); location.href='/login'; return true; }
-    if(res.status===403){ alert('요청이 거부되었습니다. 다시 시도해 주세요.'); return true; }
-    return false;
-  }
-  function resetAndReload() {
-    page = 0;
-    last = false;
-    LIST.innerHTML = '';
-    fetchList();
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
   }
 
-  function isMine(c){
-    const uid = window.CURRENT_USER_ID ?? window.currentUserId;
-    const uem = window.CURRENT_USER_EMAIL ?? window.currentUserEmail;
-    const uname = window.CURRENT_USERNAME ?? window.currentUsername;
-    if (uid != null && c.userId != null && String(uid) === String(c.userId)) return true;
-    if (uem && c.writerName && String(uem).toLowerCase() === String(c.writerName).toLowerCase()) return true;
-    if (uname && c.writerName && String(uname) === String(c.writerName)) return true;
-    return !!c.mine;
-  }
-  const enrichComment = (c)=>({ ...c, mine: isMine(c) });
+  function init() {
+    const POST_ID = window.POST_ID;
+    const LIST = document.getElementById('comment-list');
+    const FORM = document.getElementById('comment-form');
+    const INPUT = document.getElementById('comment-input');
+    const SUBMIT = document.getElementById('comment-submit');
+    const COUNT = document.getElementById('comment-count');
+    const MORE = document.getElementById('comment-load-more');
+    if (!POST_ID || !LIST) return;
 
-  async function fetchList(){
-    if(last||busy) return; busy=true;
-    try{
-      const res = await fetch(`/api/community/posts/${POST_ID}/comments?page=${page}&size=${size}`,{
-        credentials:'same-origin',
-        headers:__secureHeaders__(false)
-      });
-      if(!res.ok){ if(handleAuthFailure(res))return; return; }
-      const data = await res.json();
-      (data.content||[]).map(enrichComment).forEach(c => renderItem(c));
-      last = !!data.last;
-      if(!last){ MORE && (MORE.style.display='block'); page++; }
-      else { MORE && (MORE.style.display='none'); }
-    } finally { busy=false; }
-  }
+    let page = 0, size = 10, last = false, busy = false, composing = false;
+    let initialCountSet = false;
 
-  function renderItem(c, opts = {}) {
-    const id = c.id ?? c.commentId;
-    if (id && LIST.querySelector(`.comment-item[data-id="${id}"]`)) return;
-
-    const li=document.createElement('li');
-    li.className='comment-item';
-    li.dataset.id=id;
-    const author=esc(c.writerName || (c.userId!=null?('user#'+c.userId):'익명'));
-    const time=c.createdAt? new Date(c.createdAt).toLocaleString() : '';
-    li.innerHTML=`
-      <img class="comment-item__avatar" src="/img/profile-default.svg" alt="프로필">
-      <div class="comment-item__main">
-        <div class="comment-item__head">
-          <span class="comment-item__author">${author}</span>
-          <span class="comment-item__meta">${esc(time)}</span>
-        </div>
-        <div class="comment-item__body" data-view>${esc(c.content)}</div>
-        <div class="comment-item__actions" data-actions>
-          ${isMine(c)?`
-            <button class="comment-action edit" type="button">수정</button>
-            <button class="comment-action comment-action--danger delete" type="button">삭제</button>
-          `:''}
-        </div>
-      </div>`;
-    if (opts.prepend) LIST.prepend(li); else LIST.appendChild(li);
-  }
-
-  function cancelAnyEditing() {
-    const opened = LIST.querySelector('.comment-item[data-editing="true"]');
-    if (!opened) return;
-    exitEdit(opened, /*restore*/true);
-  }
-
-  function enterEdit(item){
-    if(item.dataset.editing === 'true') return;
-    cancelAnyEditing();
-
-    const body = item.querySelector('[data-view]');
-    const actions = item.querySelector('[data-actions]');
-    const prev = body.textContent;
-
-    const ta = document.createElement('textarea');
-    ta.className = 'comment-edit-textarea';
-    ta.value = prev;
-    ta.maxLength = 2000;
-    ta.rows = Math.min(6, Math.max(2, prev.split('\n').length));
-    body.style.display = 'none';
-    body.after(ta);
-
-    const saveBtn  = document.createElement('button');
-    const cancelBtn= document.createElement('button');
-    saveBtn.type='button'; cancelBtn.type='button';
-    saveBtn.className='comment-action save';
-    cancelBtn.className='comment-action cancel';
-    saveBtn.textContent='저장';
-    cancelBtn.textContent='취소';
-    const editBtn = actions.querySelector('.edit'); if (editBtn) editBtn.style.display='none';
-    actions.prepend(cancelBtn);
-    actions.prepend(saveBtn);
-
-    const keyHandler = (e)=>{
-      if(e.key==='Escape'){ exitEdit(item, true); }
-      if(e.key==='Enter' && (e.ctrlKey||e.metaKey)){ saveEdit(item); }
-    };
-    ta.addEventListener('keydown', keyHandler);
-    item._edit = { ta, saveBtn, cancelBtn, keyHandler, prevText: prev };
-    item.dataset.editing = 'true';
-    ta.focus();
-  }
-
-  async function saveEdit(item){
-    const ctx = item._edit; if(!ctx) return;
-    const id = item.dataset.id;
-    const next = (ctx.ta.value||'').trim();
-    if(!next){ alert('내용을 입력하세요.'); return; }
-    if(next.length>2000){ alert('댓글은 최대 2000자까지 가능합니다.'); return; }
-
-    try{
-      const res=await fetch(`/api/community/posts/${POST_ID}/comments/${id}`,{
-        method:'PUT', headers:__secureHeaders__(true), credentials:'same-origin',
-        body:JSON.stringify({ content: next })
-      });
-      if(!res.ok){ if(handleAuthFailure(res))return; alert('수정에 실패했습니다.'); return; }
-      const body = item.querySelector('[data-view]');
-      body.textContent = next;
-      exitEdit(item, /*restore*/false);
-    }catch{
-      alert('수정 중 오류가 발생했습니다.');
+    function esc(s){ return (s||'').replace(/[&<>"']/g, ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch])); }
+    function handleAuthFailure(res){
+      if(res.status===401){ alert('로그인이 필요합니다.'); location.href='/login'; return true; }
+      if(res.status===403){ alert('요청이 거부되었습니다. 다시 시도해 주세요.'); return true; }
+      return false;
     }
-  }
 
-  function exitEdit(item, restore){
-    const ctx = item._edit; if(!ctx) return;
-    const body = item.querySelector('[data-view]');
-    body.style.display = '';
-    if (restore) body.textContent = ctx.prevText;
+    function getDisplayName(c){
+      const meName = window.CURRENT_USERNAME ?? null;
+      if (c.username && String(c.username).trim()) return String(c.username);
+      if (c.writerName && String(c.writerName).trim()) return String(c.writerName);
+      if (c.user && c.user.username) return String(c.user.username);
+      if (c.mine && meName) return String(meName);
+      if (c.userId != null) return `user#${c.userId}`;
+      return '익명';
+    }
 
-    ctx.ta.remove();
-    ctx.saveBtn.remove();
-    ctx.cancelBtn.remove();
-    const actions = item.querySelector('[data-actions]');
-    const editBtn = actions.querySelector('.edit'); if (editBtn) editBtn.style.display='';
-    item.dataset.editing = 'false';
-    item._edit = null;
-  }
+    function isMine(c){
+      const uid   = window.CURRENT_USER_ID ?? window.currentUserId;
+      const uname = window.CURRENT_USERNAME ?? window.currentUsername;
+      const uem   = window.CURRENT_USER_EMAIL ?? window.currentUserEmail;
 
-  async function createComment(){
-    if(!window.IS_AUTH){ alert('로그인이 필요합니다.'); return; }
-    const content=(INPUT?.value||'').trim();
-    if(!content) return;
-    if(content.length>2000){ alert('댓글은 최대 2000자까지 가능합니다.'); return; }
-    if(busy) return;
+      if (uid != null && c.userId != null && String(uid) === String(c.userId)) return true;
+      if (uname && (c.username || c.writerName) && String(uname) === String(c.username || c.writerName)) return true;
+      if (uem && c.writerEmail && String(uem).toLowerCase() === String(c.writerEmail).toLowerCase()) return true;
+      return false;
+    }
 
-    busy=true; SUBMIT && (SUBMIT.disabled=true);
-    try{
-      const payload = { postId: POST_ID, content, parentId: null, writerName: window.CURRENT_USERNAME || window.CURRENT_USER_EMAIL || null };
-      const res=await fetch(`/api/community/posts/${POST_ID}/comments`,{
-        method:'POST', headers:__secureHeaders__(true), credentials:'same-origin',
-        body:JSON.stringify(payload)
-      });
-      if(!res.ok){ if(handleAuthFailure(res))return; alert('댓글 등록에 실패했습니다.'); return; }
-      INPUT.value='';
-      resetAndReload();
-    } finally { busy=false; SUBMIT && (SUBMIT.disabled=false); }
-  }
+    function enrichComment(c){
+      const mine = isMine(c);
+      const meName = window.CURRENT_USERNAME ?? window.currentUsername ?? null;
+      const username = c.username || (mine ? meName : null);
+      return { ...c, mine, username, writerName: c.writerName || username || c.writerName };
+    }
 
-  LIST?.addEventListener('click', async (e)=>{
-    const btn=e.target.closest('button'); if(!btn) return;
-    const item=e.target.closest('.comment-item'); if(!item) return;
-    const id=item.dataset.id;
+    async function fetchList(){
+      if(last||busy) return; busy=true;
+      try{
+        const res = await fetch(`/api/community/posts/${POST_ID}/comments?page=${page}&size=${size}`,{
+          credentials:'same-origin',
+          headers:__secureHeaders__(false)
+        });
+        if(!res.ok){ if(handleAuthFailure(res))return; return; }
+        const data = await res.json();
 
-    if(btn.classList.contains('delete')){
-      if(!confirm('이 댓글을 삭제할까요?')) return;
+        if (!initialCountSet && COUNT && typeof data.totalElements === 'number') {
+          COUNT.textContent = `댓글 ${data.totalElements}`;
+          initialCountSet = true;
+        }
+
+        (data.content||[]).map(enrichComment).forEach(c => renderItem(c));
+        last = !!data.last;
+        if(!last){ MORE && (MORE.style.display='block'); page++; }
+        else { MORE && (MORE.style.display='none'); }
+      } finally { busy=false; }
+    }
+
+    function renderItem(c, opts = {}) {
+      const id = c.id ?? c.commentId;
+      if (id && LIST.querySelector(`.comment-item[data-id="${id}"]`)) return;
+
+      const li=document.createElement('li');
+      li.className='comment-item';
+      li.dataset.id=id;
+      const author = esc(getDisplayName(c));
+      const time = c.createdAt ? new Date(c.createdAt).toLocaleString() : '';
+      li.innerHTML=`
+        <img class="comment-item__avatar" src="${esc(c.profileImageUrl || '/img/profile-default.svg')}" alt="프로필">
+        <div class="comment-item__main">
+          <div class="comment-item__head">
+            <span class="comment-item__author">${author}</span>
+            <span class="comment-item__meta">${esc(time)}</span>
+          </div>
+          <div class="comment-item__body" data-view>${esc(c.content)}</div>
+          <div class="comment-item__actions" data-actions>
+            ${isMine(c)?`
+              <button class="comment-action edit" type="button">수정</button>
+              <button class="comment-action comment-action--danger delete" type="button">삭제</button>
+            `:''}
+          </div>
+        </div>`;
+      if (opts.prepend) LIST.prepend(li); else LIST.appendChild(li);
+    }
+
+    function exitEdit(item, restore){
+      const ctx=item._edit; if(!ctx) return;
+      const body=item.querySelector('[data-view]');
+      if(restore) body.textContent = ctx.prevText;
+      body.style.display='';
+      ctx.ta.remove();
+      ctx.saveBtn.remove();
+      ctx.cancelBtn.remove();
+      const editBtn = item.querySelector('.comment-action.edit'); if (editBtn) editBtn.style.display='';
+      item.removeAttribute('data-editing');
+      item._edit = null;
+    }
+
+    function enterEdit(item){
+      if(item.dataset.editing === 'true') return;
+      const body = item.querySelector('[data-view]');
+      const actions = item.querySelector('[data-actions]');
+      const prev = body.textContent;
+
+      const ta = document.createElement('textarea');
+      ta.className = 'comment-edit-textarea';
+      ta.value = prev;
+      ta.maxLength = 2000;
+      ta.rows = Math.min(6, Math.max(2, prev.split('\n').length));
+      body.style.display = 'none';
+      body.after(ta);
+
+      const saveBtn  = document.createElement('button');
+      const cancelBtn= document.createElement('button');
+      saveBtn.type='button'; cancelBtn.type='button';
+      saveBtn.className='comment-action save';
+      cancelBtn.className='comment-action cancel';
+      saveBtn.textContent='저장';
+      cancelBtn.textContent='취소';
+      const editBtn = actions.querySelector('.edit'); if (editBtn) editBtn.style.display='none';
+      actions.prepend(cancelBtn);
+      actions.prepend(saveBtn);
+
+      const keyHandler = (e)=>{
+        if(e.key==='Escape'){ exitEdit(item, true); }
+        if(e.key==='Enter' && (e.ctrlKey||e.metaKey)){ saveEdit(item); }
+      };
+      ta.addEventListener('keydown', keyHandler);
+      item._edit = { ta, saveBtn, cancelBtn, keyHandler, prevText: prev };
+      item.dataset.editing = 'true';
+
+      saveBtn.addEventListener('click', ()=>saveEdit(item));
+      cancelBtn.addEventListener('click', ()=>exitEdit(item, true));
+      ta.focus();
+    }
+
+    async function saveEdit(item){
+      const ctx = item._edit; if(!ctx) return;
+      const id = item.dataset.id;
+      const next = (ctx.ta.value||'').trim();
+      if(!next){ alert('내용을 입력하세요.'); return; }
+      if(next.length>2000){ alert('댓글은 최대 2000자까지 가능합니다.'); return; }
+
       try{
         const res=await fetch(`/api/community/posts/${POST_ID}/comments/${id}`,{
+          method:'PUT', headers:__secureHeaders__(true), credentials:'same-origin',
+          body:JSON.stringify({ content: next })
+        });
+        if(!res.ok){ if(handleAuthFailure(res))return; alert('수정에 실패했습니다.'); return; }
+        const body = item.querySelector('[data-view]');
+        body.textContent = next;
+        exitEdit(item, false);
+      }catch{
+        alert('수정 중 오류가 발생했습니다.');
+      }
+    }
+
+    async function deleteComment(item){
+      const id = item.dataset.id;
+      if(!id) return;
+      if(!confirm('이 댓글을 삭제할까요?')) return;
+      try{
+        const res = await fetch(`/api/community/posts/${POST_ID}/comments/${id}`,{
           method:'DELETE', headers:__secureHeaders__(false), credentials:'same-origin'
         });
         if(!res.ok){ if(handleAuthFailure(res))return; alert('삭제에 실패했습니다.'); return; }
         item.remove();
-      }catch{ alert('삭제 중 오류가 발생했습니다.'); }
-      return;
+        bumpCount(-1);
+      }catch{
+        alert('삭제 중 오류가 발생했습니다.');
+      }
     }
 
-    if(btn.classList.contains('edit')){
-      enterEdit(item);
-      return;
+    function bumpCount(delta){
+      if(!COUNT) return;
+      const n = parseInt((COUNT.textContent||'').replace(/\D/g,''),10);
+      const cur = isNaN(n)?0:n;
+      COUNT.textContent = `댓글 ${cur + delta}`;
     }
 
-    if(btn.classList.contains('save')){
-      await saveEdit(item);
-      return;
+    function hydrateSavedForUI(saved, submittedContent){
+      const nowIso = new Date().toISOString();
+      const currentUid   = window.CURRENT_USER_ID ?? window.currentUserId ?? null;
+      const currentName  = window.CURRENT_USERNAME ?? null;
+      const currentEmail = window.CURRENT_USER_EMAIL ?? null;
+
+      const username = (saved && (saved.username || saved.writerName || saved.writerEmail))
+                        || currentName || currentEmail || (currentUid!=null?`user#${currentUid}`:null);
+
+      return {
+        id: saved?.id ?? saved?.commentId ?? null,
+        userId: saved?.userId ?? currentUid,
+        username: username,
+        writerName: saved?.writerName ?? username,
+        writerEmail: saved?.writerEmail ?? currentEmail ?? null,
+        content: saved?.content ?? submittedContent,
+        createdAt: saved?.createdAt ?? nowIso,
+        profileImageUrl: saved?.profileImageUrl ?? null,
+        mine: true
+      };
     }
 
-    if(btn.classList.contains('cancel')){
-      exitEdit(item, /*restore*/true);
-      return;
+    async function postComment(content){
+      const res = await fetch(`/api/community/posts/${POST_ID}/comments`, {
+        method: 'POST',
+        headers: __secureHeaders__(true),
+        credentials: 'same-origin',
+        body: JSON.stringify({ content })
+      });
+      if (!res.ok) {
+        if (handleAuthFailure(res)) return null;
+        alert('댓글 등록에 실패했습니다.');
+        return null;
+      }
+      try { return await res.json(); } catch { return {}; }
     }
-  });
 
-  MORE?.addEventListener('click', fetchList);
-  const keyHandler=(e)=>{ if(e.isComposing) return; if(e.key==='Enter'&&!e.shiftKey){ e.preventDefault(); createComment(); } };
-  INPUT?.addEventListener('keydown', keyHandler);
-  SUBMIT?.addEventListener('click', createComment);
+    async function handleSubmit(){
+      if (!INPUT) return;
+      const val = (INPUT.value||'').trim();
+      if (!val) { INPUT.focus(); return; }
+      if (val.length > 2000) { alert('댓글은 최대 2000자까지 가능합니다.'); return; }
 
-  fetchList();
+      if (SUBMIT) { SUBMIT.disabled = true; SUBMIT.classList.add('is-loading'); }
+      try{
+        const saved = await postComment(val);
+        if (saved === null) return;
+        const uiObj = hydrateSavedForUI(saved, val);
+        const enriched = enrichComment(uiObj);
+        renderItem(enriched, { prepend: true });
+        INPUT.value = '';
+        INPUT.blur();
+        bumpCount(+1);
+      } finally {
+        if (SUBMIT) { SUBMIT.disabled = false; SUBMIT.classList.remove('is-loading'); }
+      }
+    }
+
+    MORE && MORE.addEventListener('click', fetchList);
+
+    if (FORM) FORM.addEventListener('submit', (e)=>{ e.preventDefault(); handleSubmit(); });
+    if (SUBMIT) {
+      SUBMIT.addEventListener('click', (e)=>{ e.preventDefault(); handleSubmit(); });
+      if (!SUBMIT.getAttribute('type')) SUBMIT.setAttribute('type','submit');
+    }
+    if (INPUT) {
+      INPUT.addEventListener('compositionstart', ()=>{ composing = true; });
+      INPUT.addEventListener('compositionend',   ()=>{ composing = false; });
+      INPUT.addEventListener('keydown', (e)=>{
+        if ((e.ctrlKey||e.metaKey) && e.key === 'Enter') { e.preventDefault(); handleSubmit(); }
+        if (!e.ctrlKey && !e.metaKey && e.key === 'Enter' && !composing && FORM) { e.preventDefault(); handleSubmit(); }
+      });
+    }
+
+    LIST.addEventListener('click',(e)=>{
+      const target = e.target;
+      if (target.closest('.comment-action.delete')) {
+        const item = target.closest('.comment-item'); if(item) deleteComment(item);
+      } else if (target.closest('.comment-action.edit')) {
+        const item = target.closest('.comment-item'); if(item) enterEdit(item);
+      }
+    });
+
+    fetchList();
+  }
 })();
-
-document.addEventListener('click', async (e)=>{
-  const likeBtn = e.target.closest('.btn-like');
-  const scrapBtn = e.target.closest('.btn-scrap');
-
-  const toggle = async (btn)=>{
-    const url = btn.dataset.url;
-    if(!url) return;
-    try{
-      const res = await fetch(url,{ method:'POST', headers:__secureHeaders__(false), credentials:'same-origin' });
-      if(!res.ok) throw new Error();
-      const data = await res.json();
-      const active = !!data.active;
-      btn.classList.toggle('active', active);
-      const icon = btn.querySelector('i');
-      if(icon){
-        icon.classList.toggle('fa-solid', active);
-        icon.classList.toggle('fa-regular', !active);
-      }
-      btn.querySelector('.count').textContent = data.count;
-    }catch{
-      const active = btn.classList.toggle('active');
-      const span = btn.querySelector('.count');
-      const cur = parseInt(span.textContent||'0',10);
-      span.textContent = Math.max(0, cur + (active?1:-1));
-      const icon = btn.querySelector('i');
-      if(icon){
-        icon.classList.toggle('fa-solid', active);
-        icon.classList.toggle('fa-regular', !active);
-      }
-    }
-  };
-
-  if(likeBtn)  await toggle(likeBtn);
-  if(scrapBtn) await toggle(scrapBtn);
-});
-
-if(window.POST_ID){
-  fetch(`/api/community/posts/${window.POST_ID}/view`,{
-    method:'POST', credentials:'same-origin', headers:__secureHeaders__(false)
-  })
-  .then(r=>r.ok?r.json():null)
-  .then(d=>{
-    if(d?.viewCount!=null){
-      const el=document.getElementById('view-count');
-      if(el) el.textContent=d.viewCount;
-    }
-  })
-  .catch(()=>{});
-}

--- a/src/main/resources/templates/community/community.html
+++ b/src/main/resources/templates/community/community.html
@@ -23,13 +23,11 @@
     </header>
 
     <div class="filter-bar">
-        <!-- 1) 검색 (상단, 가로 전체) -->
         <form id="searchForm" class="search-box" action="javascript:void(0);">
             <input id="keywordInput" type="text" name="keyword" placeholder="면접 결과 검색..." />
             <button type="submit" aria-label="검색"><i class="fa fa-search"></i></button>
         </form>
 
-        <!-- 2) 같은 줄: 왼(정렬) / 중간(카테고리) / 오른쪽(레벨) -->
         <div class="left-controls">
             <select id="sortSelect" name="sort" aria-label="정렬">
                 <option value="createdAt,desc" selected>최신순</option>

--- a/src/main/resources/templates/community/post-detail.html
+++ b/src/main/resources/templates/community/post-detail.html
@@ -14,10 +14,12 @@
     <meta name="_csrf_header" th:content="${_csrf.headerName}">
 
     <script th:inline="javascript">
-        window.IS_AUTH  = [[${#authorization.expression('isAuthenticated()')}]];
-        window.POST_ID  = [[${post.id}]];
-        window.CURRENT_USERNAME = [[${#authentication} != null ? ${#authentication.name} : null]];
+        window.CURRENT_USER_ID    = [[${#authentication?.principal?.userId}]];
+        window.CURRENT_USERNAME   = /*[['${#authentication?.name}']]*/ null;
+        window.CURRENT_USER_EMAIL = /*[['${#authentication?.principal?.email}']]*/ null;
+        window.POST_ID            = [[${post.id}]];
     </script>
+
 </head>
 
 <body data-page="detail">
@@ -77,12 +79,16 @@
             <div class="comments">
                 <div class="comments__title">
                     <span>댓글</span>
-                    <span class="comments__badge"
-                          th:text="${comments} != null ? ${#lists.size(comments)} + '개' : '0개'">0개</span>
+                    <span class="comments__badge">
+                        <span id="comment-count"
+                              th:text="${comments} != null ? ${#lists.size(comments)} : 0">0</span>개
+                    </span>
                 </div>
 
-                <form class="comment-form" onsubmit="return false;">
-                    <textarea id="comment-input" name="content" placeholder="댓글을 입력하세요..." required></textarea>
+
+                <form id="comment-form" class="comment-form" onsubmit="return false;">
+
+                <textarea id="comment-input" name="content" placeholder="댓글을 입력하세요..." required></textarea>
                     <button id="comment-submit" type="button" class="btn-submit"
                             th:disabled="${#authorization.expression('!isAuthenticated()')}">등록</button>
                 </form>
@@ -92,10 +98,12 @@
             </div>
         </section>
 
-        <div style="margin-top:16px; display:flex; justify-content:flex-end;">
-            <a class="read-more" th:href="@{/community}">목록으로 가기</a>
+        <div class="post-detail__nav">
+            <a th:href="@{/community}" id="btn-back-to-list">
+                <i class="fa fa-list-ul" aria-hidden="true"></i>
+                목록
+            </a>
         </div>
-
     </div>
 </main>
 


### PR DESCRIPTION
- 이번 PR은 기존 PR #44(`feature/community-comments`)의 내용 복구했습니다.

## 복구 배경
- develop 브랜치에 아래 Revert 커밋들이 머지되면서 댓글 관련 기능이 사라짐:
  - ccd3d8d: Revert "Merge pull request #44 from .../feature/community-comments"
  - (연관된 revert-39-feature/community-comments-delete 포함)
- hotfix/restore-comments 브랜치에서 `ccd3d8d`를 되돌리는(revert-revert) 방식으로 복구

## 주요 복구 내용
- **댓글 CRUD**: 등록, 수정, 삭제 기능
- **댓글 작성자 표시 로직**: 작성자명/username 표시
- **댓글 개수 표시**: 등록/삭제 시 즉시 갱신
- 관련 프론트 리소스(JS/CSS/HTML) 및 백엔드 로직(Controller, Service, Repository, DTO) 복원

## 변경 파일 주요 목록
- `CommentsController.java`
- `CommentsService.java`
- `CommentsRepository.java`
- `CommunityPosts.java`
- `CommentsDto.java`
- `community.html`, `post-detail.html`
- `post-detail-comments.js`, `post-detail.css`