### PR TITLE
feat: 회원 탈퇴 기능 및 데이터 정리 구현

### DIFF
--- a/src/main/java/com/allinone/DevView/mypage/controller/MypageController.java
+++ b/src/main/java/com/allinone/DevView/mypage/controller/MypageController.java
@@ -6,11 +6,14 @@ import com.allinone.DevView.mypage.dto.MypageResponseDto;
 import com.allinone.DevView.mypage.dto.ScoreGraphDto;
 import com.allinone.DevView.mypage.service.MypageService;
 import com.allinone.DevView.user.dto.response.UserResponse;
+import com.allinone.DevView.user.service.UserService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;  // 추가
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.List;
@@ -18,9 +21,11 @@ import java.util.List;
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/mypage")
+@Slf4j  // 추가
 public class MypageController {
 
     private final MypageService mypageService;
+    private final UserService userService;
 
     @GetMapping
     public String showMyPage(Model model, HttpSession session) {
@@ -61,5 +66,49 @@ public class MypageController {
         }
         model.addAttribute("user", mypageService.getBasicUserInfo(loginUser.getUserId()));
         return "mypage/mypage-edit";
+    }
+
+    /**
+     * 회원탈퇴 처리
+     * POST /mypage/delete
+     */
+    @PostMapping("/delete")
+    public String deleteUser(HttpSession session) {
+        log.info("회원탈퇴 요청");
+
+        try {
+            UserResponse loginUser = (UserResponse) session.getAttribute("loginUser");
+            if (loginUser == null) {
+                log.warn("로그인되지 않은 사용자의 탈퇴 시도");
+                return "redirect:/user/login?error=authentication_required";
+            }
+
+            Long userId = loginUser.getUserId();
+            String userEmail = loginUser.getEmail();
+
+            // 추가 보안: 현재 세션의 사용자가 실제로 존재하는지 확인
+            try {
+                userService.getUserById(userId);
+            } catch (Exception e) {
+                log.warn("존재하지 않는 사용자의 탈퇴 시도: userId={}, email={}", userId, userEmail);
+                session.invalidate();
+                return "redirect:/user/login?error=user_not_found";
+            }
+
+            // 회원탈퇴 처리
+            userService.deleteUser(userId);
+
+            // 즉시 세션 무효화 (보안상 중요)
+            session.invalidate();
+
+            log.info("회원탈퇴 완료: userId={}, email={}", userId, userEmail);
+
+            // 탈퇴 완료 후 메인 페이지로 리다이렉트
+            return "redirect:/?message=withdrawal_success";
+
+        } catch (Exception e) {
+            log.error("회원탈퇴 처리 중 오류 발생", e);
+            return "redirect:/mypage?error=withdrawal_failed";
+        }
     }
 }

--- a/src/main/java/com/allinone/DevView/user/repository/UserRepository.java
+++ b/src/main/java/com/allinone/DevView/user/repository/UserRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -41,4 +43,65 @@ public interface UserRepository extends JpaRepository<User, Long> {
      */
     @Query("SELECT u FROM User u WHERE u.provider = 'LOCAL' OR u.provider IS NULL")
     Optional<User> findLocalUserByEmail(@Param("email") String email);
+
+    /**
+     * 회원탈퇴 시 관련 데이터 삭제
+     * 외래키 제약 조건을 고려하여 순서대로 삭제
+     */
+    @Modifying
+    @Transactional
+    @Query(value = """
+        -- 1. 면접 관련 데이터 삭제 (답변 -> 질문 -> 결과 -> 면접)
+        DELETE FROM interview_answers WHERE question_id IN (
+            SELECT question_id FROM interview_questions WHERE interview_id IN (
+                SELECT interview_id FROM interviews WHERE user_id = :userId
+            )
+        );
+        DELETE FROM interview_questions WHERE interview_id IN (
+            SELECT interview_id FROM interviews WHERE user_id = :userId
+        );
+        DELETE FROM interview_results WHERE interview_id IN (
+            SELECT interview_id FROM interviews WHERE user_id = :userId
+        );
+        DELETE FROM interviews WHERE user_id = :userId;
+        
+        -- 2. 커뮤니티 관련 데이터 삭제 (자식부터 부모 순서로)
+        -- 2-1. 먼저 스크랩 삭제 (사용자가 스크랩한 것들)
+        DELETE FROM scraps WHERE user_id = :userId;
+        
+        -- 2-2. 사용자 게시글에 달린 스크랩들 삭제
+        DELETE FROM scraps WHERE post_id IN (
+            SELECT id FROM community_posts WHERE user_id = :userId
+        );
+        
+        -- 2-3. 좋아요 삭제 (사용자가 누른 것들)
+        DELETE FROM likes WHERE user_id = :userId;
+        
+        -- 2-4. 사용자 게시글에 달린 좋아요들 삭제
+        DELETE FROM likes WHERE post_id IN (
+            SELECT id FROM community_posts WHERE user_id = :userId
+        );
+        
+        -- 2-5. 댓글 삭제 (사용자가 쓴 댓글)
+        DELETE FROM comments WHERE user_id = :userId;
+        
+        -- 2-6. 사용자 게시글에 달린 댓글들 삭제
+        DELETE FROM comments WHERE post_id IN (
+            SELECT id FROM community_posts WHERE user_id = :userId
+        );
+        
+        -- 2-7. 마지막으로 게시글 삭제
+        DELETE FROM community_posts WHERE user_id = :userId;
+        
+        -- 3. 랭킹 데이터 삭제
+        DELETE FROM user_rankings WHERE user_id = :userId;
+        
+        -- 4. 프로필 데이터 삭제
+        DELETE FROM user_profiles WHERE user_id = :userId;
+        
+        -- 5. 마지막으로 사용자 삭제
+        DELETE FROM users WHERE user_id = :userId;
+        """, nativeQuery = true)
+    void deleteUserRelatedData(@Param("userId") Long userId);
+
 }

--- a/src/main/java/com/allinone/DevView/user/service/UserService.java
+++ b/src/main/java/com/allinone/DevView/user/service/UserService.java
@@ -93,6 +93,30 @@ public class UserService {
         return !userRepository.existsByUsername(username);
     }
 
+    /**
+     * 회원탈퇴 처리 (하드 삭제)
+     * 관련된 모든 데이터를 순서대로 삭제한 후 사용자 삭제
+     */
+    @Transactional
+    public void deleteUser(Long userId) {
+        log.info("회원탈퇴 처리 시작: userId={}", userId);
+
+        // 1. 사용자 존재 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        try {
+            // 2. 관련 데이터 삭제 (User 포함, 모든 삭제를 Native Query로 처리)
+            userRepository.deleteUserRelatedData(userId);
+
+            log.info("회원탈퇴 완료: userId={}, email={}", userId, user.getEmail());
+
+        } catch (Exception e) {
+            log.error("회원탈퇴 처리 중 오류 발생: userId={}", userId, e);
+            throw new RuntimeException("회원탈퇴 처리 실패", e);
+        }
+    }
+
     // === Private Helper Methods ===
 
     private void validateRegisterRequest(RegisterRequest request) {

--- a/src/main/resources/static/js/mypage.js
+++ b/src/main/resources/static/js/mypage.js
@@ -1,4 +1,6 @@
 document.addEventListener("DOMContentLoaded", function () {
+    console.log('mypage.js 로드됨'); // 디버깅용
+
     // 1) 점수 변화 라인차트
     const scoreCtx = document.getElementById("scoreChart");
     if (scoreCtx) {
@@ -14,37 +16,36 @@ document.addEventListener("DOMContentLoaded", function () {
         // 혹시 문자열 숫자가 섞여 있으면 숫자로 보정
         scores = (scores || []).map(n => typeof n === 'string' ? Number(n) : n);
 
-        if (typeof Chart === 'undefined') {
+        if (typeof Chart !== 'undefined') {
+            new Chart(scoreCtx, {
+                type: 'line',
+                data: {
+                    labels: labels.length > 0 ? labels : ["데이터 없음"],
+                    datasets: [{
+                        label: '면접 점수',
+                        data: scores.length > 0 ? scores : [0],
+                        borderColor: '#4AB2E3',
+                        backgroundColor: 'rgba(74, 178, 227, 0.1)',
+                        borderWidth: 2,
+                        fill: true,
+                        tension: 0.3,
+                        pointBackgroundColor: '#4AB2E3',
+                        pointRadius: 4
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: { legend: { display: false }, title: { display: false } },
+                    scales: { y: { beginAtZero: true, max: 100, ticks: { stepSize: 20 } } }
+                }
+            });
+        } else {
             console.error('Chart.js가 로드되지 않았습니다.');
-            return;
         }
-
-        new Chart(scoreCtx, {
-            type: 'line',
-            data: {
-                labels: labels.length > 0 ? labels : ["데이터 없음"],
-                datasets: [{
-                    label: '면접 점수',
-                    data: scores.length > 0 ? scores : [0],
-                    borderColor: '#4AB2E3',
-                    backgroundColor: 'rgba(74, 178, 227, 0.1)',
-                    borderWidth: 2,
-                    fill: true,
-                    tension: 0.3,
-                    pointBackgroundColor: '#4AB2E3',
-                    pointRadius: 4
-                }]
-            },
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                plugins: { legend: { display: false }, title: { display: false } },
-                scales: { y: { beginAtZero: true, max: 100, ticks: { stepSize: 20 } } }
-            }
-        });
     }
 
-    // 2) 관심 직무 도넛차트 (동일한 방식)
+    // 2) 관심 직무 도넛차트
     const careerCtx = document.getElementById("careerChart");
     if (careerCtx) {
         let labels = [];
@@ -56,30 +57,255 @@ document.addEventListener("DOMContentLoaded", function () {
             console.error('관심 직무 데이터 파싱 오류', e);
         }
 
-        if (typeof Chart === 'undefined') return;
-
-        new Chart(careerCtx, {
-            type: 'doughnut',
-            data: {
-                labels: labels.length > 0 ? labels : ["데이터 없음"],
-                datasets: [{
-                    label: '관심 직무',
-                    data: data.length > 0 ? data : [1],
-                    backgroundColor: [
-                        'rgba(255, 99, 132, 0.6)',
-                        'rgba(54, 162, 235, 0.6)',
-                        'rgba(255, 206, 86, 0.6)',
-                        'rgba(75, 192, 192, 0.6)',
-                        'rgba(153, 102, 255, 0.6)',
-                        'rgba(255, 159, 64, 0.6)'
-                    ],
-                    borderWidth: 1
-                }]
-            },
-            options: {
-                responsive: true,
-                plugins: { legend: { position: 'bottom' }, title: { display: false } }
-            }
-        });
+        if (typeof Chart !== 'undefined') {
+            new Chart(careerCtx, {
+                type: 'doughnut',
+                data: {
+                    labels: labels.length > 0 ? labels : ["데이터 없음"],
+                    datasets: [{
+                        label: '관심 직무',
+                        data: data.length > 0 ? data : [1],
+                        backgroundColor: [
+                            'rgba(255, 99, 132, 0.6)',
+                            'rgba(54, 162, 235, 0.6)',
+                            'rgba(255, 206, 86, 0.6)',
+                            'rgba(75, 192, 192, 0.6)',
+                            'rgba(153, 102, 255, 0.6)',
+                            'rgba(255, 159, 64, 0.6)'
+                        ],
+                        borderWidth: 1
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    plugins: { legend: { position: 'bottom' }, title: { display: false } }
+                }
+            });
+        }
     }
+
+    // 3) 회원탈퇴 모달 기능
+    initWithdrawalModal();
 });
+
+// ===== 회원탈퇴 모달 관련 함수들 =====
+
+function initWithdrawalModal() {
+    console.log('회원탈퇴 모달 초기화 시작'); // 디버깅용
+
+    // 탈퇴 폼 찾기 - 여러 방법으로 시도
+    const withdrawalForm = document.querySelector('#withdrawalForm') ||
+                          document.querySelector('form[action="/mypage/delete"]');
+
+    if (withdrawalForm) {
+        console.log('탈퇴 폼 찾음:', withdrawalForm); // 디버깅용
+
+        // 기존 onsubmit 속성 제거
+        withdrawalForm.removeAttribute('onsubmit');
+
+        // 새로운 이벤트 리스너 추가
+        withdrawalForm.addEventListener('submit', function(e) {
+            console.log('탈퇴 버튼 클릭됨'); // 디버깅용
+            e.preventDefault(); // 기본 제출 방지
+
+            // 커스텀 확인 모달 표시
+            showWithdrawalConfirmModal(withdrawalForm);
+        });
+    } else {
+        console.error('탈퇴 폼을 찾을 수 없습니다');
+    }
+}
+
+/**
+ * 회원탈퇴 확인 모달 표시
+ * @param {HTMLFormElement} form 제출할 폼 엘리먼트
+ */
+function showWithdrawalConfirmModal(form) {
+    console.log('모달 표시'); // 디버깅용
+
+    // 모달 HTML 생성
+    const modalHTML = `
+        <div id="withdrawalModal" class="withdrawal-modal-overlay">
+            <div class="withdrawal-modal">
+                <div class="modal-header">
+                    <h3>회원탈퇴 확인</h3>
+                </div>
+                <div class="modal-body">
+                    <p><strong>정말로 탈퇴하시겠습니까?</strong></p>
+                    <p>탈퇴 시 다음 데이터가 모두 삭제됩니다:</p>
+                    <ul>
+                        <li>프로필 정보</li>
+                        <li>면접 기록 및 결과</li>
+                        <li>커뮤니티 글 및 댓글</li>
+                        <li>랭킹 정보</li>
+                    </ul>
+                    <p class="warning">⚠️ 이 작업은 되돌릴 수 없습니다.</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="modal-btn cancel-btn" onclick="closeWithdrawalModal()">
+                        취소
+                    </button>
+                    <button type="button" class="modal-btn confirm-btn" onclick="confirmWithdrawal()">
+                        탈퇴하기
+                    </button>
+                </div>
+            </div>
+        </div>
+    `;
+
+    // CSS 스타일 추가 (한 번만)
+    if (!document.getElementById('withdrawalModalStyles')) {
+        const styles = `
+            <style id="withdrawalModalStyles">
+                .withdrawal-modal-overlay {
+                    position: fixed;
+                    top: 0;
+                    left: 0;
+                    width: 100%;
+                    height: 100%;
+                    background: rgba(0, 0, 0, 0.5);
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
+                    z-index: 10000;
+                }
+
+                .withdrawal-modal {
+                    background: white;
+                    border-radius: 12px;
+                    width: 90%;
+                    max-width: 450px;
+                    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+                    animation: modalAppear 0.2s ease-out;
+                }
+
+                @keyframes modalAppear {
+                    from {
+                        opacity: 0;
+                        transform: scale(0.9) translateY(-20px);
+                    }
+                    to {
+                        opacity: 1;
+                        transform: scale(1) translateY(0);
+                    }
+                }
+
+                .modal-header {
+                    padding: 20px 24px 0;
+                    border-bottom: none;
+                }
+
+                .modal-header h3 {
+                    margin: 0;
+                    font-size: 1.25rem;
+                    font-weight: 600;
+                    color: #dc3545;
+                }
+
+                .modal-body {
+                    padding: 16px 24px;
+                }
+
+                .modal-body p {
+                    margin: 0 0 12px 0;
+                    line-height: 1.5;
+                }
+
+                .modal-body ul {
+                    margin: 12px 0;
+                    padding-left: 20px;
+                }
+
+                .modal-body li {
+                    margin: 4px 0;
+                    color: #666;
+                }
+
+                .modal-body .warning {
+                    color: #dc3545;
+                    font-weight: 500;
+                    background: #fff5f5;
+                    padding: 8px 12px;
+                    border-radius: 6px;
+                    border-left: 4px solid #dc3545;
+                }
+
+                .modal-footer {
+                    padding: 16px 24px 24px;
+                    display: flex;
+                    gap: 12px;
+                    justify-content: flex-end;
+                }
+
+                .modal-btn {
+                    padding: 10px 20px;
+                    border-radius: 8px;
+                    font-size: 0.9rem;
+                    font-weight: 500;
+                    cursor: pointer;
+                    transition: all 0.2s;
+                    border: none;
+                }
+
+                .cancel-btn {
+                    background: #f8f9fa;
+                    color: #495057;
+                    border: 1px solid #dee2e6;
+                }
+
+                .cancel-btn:hover {
+                    background: #e9ecef;
+                }
+
+                .confirm-btn {
+                    background: #dc3545;
+                    color: white;
+                }
+
+                .confirm-btn:hover {
+                    background: #c82333;
+                }
+            </style>
+        `;
+        document.head.insertAdjacentHTML('beforeend', styles);
+    }
+
+    // 모달을 body에 추가
+    document.body.insertAdjacentHTML('beforeend', modalHTML);
+
+    // 폼 엘리먼트를 전역 변수에 저장
+    window.withdrawalForm = form;
+
+    // ESC 키로 모달 닫기
+    document.addEventListener('keydown', handleModalKeydown);
+}
+
+/**
+ * 모달 닫기
+ */
+function closeWithdrawalModal() {
+    console.log('모달 닫기'); // 디버깅용
+    const modal = document.getElementById('withdrawalModal');
+    if (modal) {
+        modal.remove();
+    }
+    window.withdrawalForm = null;
+    document.removeEventListener('keydown', handleModalKeydown);
+}
+
+/**
+ * 탈퇴 확인
+ */
+function confirmWithdrawal() {
+    console.log('탈퇴 확인 버튼 클릭'); // 디버깅용
+
+    const form = window.withdrawalForm;
+    closeWithdrawalModal();
+
+    if (form) {
+        console.log('폼 제출 시작:', form); // 디버깅용
+        form.submit();
+    } else {
+        console.error('폼을 찾을 수 없습니다');
+    }
+}

--- a/src/main/resources/templates/mypage/mypage.html
+++ b/src/main/resources/templates/mypage/mypage.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8" />
     <title>마이페이지</title>
+    <!-- CSRF 토큰 메타 태그 추가 -->
+    <meta name="_csrf" th:content="${_csrf.token}" />
+    <meta name="_csrf_header" th:content="${_csrf.headerName}" />
+
     <link rel="stylesheet" th:href="@{/css/mypage.css}" />
     <link rel="stylesheet" th:href="@{/css/header.css}" />
     <script th:src="@{/js/lib/chart.min.js}"></script>
@@ -45,8 +49,9 @@
                             프로필 수정
                         </button>
                     </form>
-                    <form th:action="@{/mypage/delete}" method="post"
-                          onsubmit="return confirm('정말로 탈퇴하시겠습니까? 이 작업은 되돌릴 수 없습니다.')">
+                    <form th:action="@{/mypage/delete}" method="post" id="withdrawalForm">
+                        <!-- CSRF 토큰 히든 필드 추가 -->
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                         <button type="submit" class="btn danger">
                             <img src="/img/bye.svg" class="icon" alt="회원 탈퇴" />
                             회원 탈퇴


### PR DESCRIPTION
- 마이페이지에 회원 탈퇴 기능 추가 (확인 모달 포함)
- 백엔드에서 사용자 및 연관 데이터 하드 삭제 로직 구현
- UserRepository에 네이티브 쿼리 추가하여 연관 데이터 삭제 순서 보장
- UserService에서 탈퇴 프로세스 처리
- 프론트엔드에 맞춤형 탈퇴 확인 모달 적용
- 탈퇴 폼에 CSRF 보호 적용