### PR TITLE
feat: 프로필 이미지 AWS S3 연동 및 랭킹 페이지 반영

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-database-postgresql</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>s3</artifactId>
+			<version>2.29.15</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/allinone/DevView/config/S3Config.java
+++ b/src/main/java/com/allinone/DevView/config/S3Config.java
@@ -1,0 +1,29 @@
+package com.allinone.DevView.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${AWS_ACCESS_KEY_ID}")
+    private String accessKey;
+
+    @Value("${AWS_SECRET_ACCESS_KEY}")
+    private String secretKey;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Client.builder()
+                .region(Region.AP_NORTHEAST_2)  // 하드코딩으로 서울 리전 설정
+                .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/allinone/DevView/config/S3Service.java
+++ b/src/main/java/com/allinone/DevView/config/S3Service.java
@@ -1,0 +1,168 @@
+package com.allinone.DevView.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    // 버킷 이름 하드코딩 (테스트용)
+    private static final String BUCKET_NAME = "devview-allinone";
+    private static final String REGION = "ap-northeast-2";
+
+    /**
+     * S3에 파일 업로드
+     * @param file 업로드할 파일
+     * @param folder S3 내 폴더 경로 (예: "profile/123")
+     * @return S3 URL
+     */
+    public String uploadFile(MultipartFile file, String folder) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("업로드할 파일이 없습니다.");
+        }
+
+        String originalFileName = file.getOriginalFilename();
+        String fileName = generateFileName(originalFileName);
+        String key = folder + "/" + fileName;
+
+        try {
+            // 파일 메타데이터 설정 (ACL 제거)
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(BUCKET_NAME)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .contentLength(file.getSize())
+                    .build();
+
+            // S3에 업로드
+            s3Client.putObject(putObjectRequest,
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+            // 업로드된 파일의 URL 반환
+            String url = generateFileUrl(key);
+            log.info("파일 업로드 성공: {}", url);
+            return url;
+
+        } catch (IOException e) {
+            log.error("파일 업로드 실패: {}", key, e);
+            throw new RuntimeException("S3 파일 업로드에 실패했습니다.", e);
+        }
+    }
+
+    /**
+     * S3에서 파일 삭제
+     * @param fileUrl 삭제할 파일의 S3 URL
+     */
+    public void deleteFile(String fileUrl) {
+        if (fileUrl == null || fileUrl.isEmpty()) {
+            return;
+        }
+
+        try {
+            String key = extractKeyFromUrl(fileUrl);
+            if (key == null) {
+                log.warn("URL에서 S3 키를 추출할 수 없습니다: {}", fileUrl);
+                return;
+            }
+
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(BUCKET_NAME)
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("파일 삭제 성공: {}", key);
+
+        } catch (Exception e) {
+            log.error("파일 삭제 실패: {}", fileUrl, e);
+            throw new RuntimeException("S3 파일 삭제에 실패했습니다.", e);
+        }
+    }
+
+    /**
+     * 파일 존재 여부 확인
+     * @param fileUrl S3 파일 URL
+     * @return 존재 여부
+     */
+    public boolean fileExists(String fileUrl) {
+        if (fileUrl == null || fileUrl.isEmpty()) {
+            return false;
+        }
+
+        try {
+            String key = extractKeyFromUrl(fileUrl);
+            if (key == null) return false;
+
+            HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
+                    .bucket(BUCKET_NAME)
+                    .key(key)
+                    .build();
+
+            s3Client.headObject(headObjectRequest);
+            return true;
+
+        } catch (NoSuchKeyException e) {
+            return false;
+        } catch (Exception e) {
+            log.error("파일 존재 확인 실패: {}", fileUrl, e);
+            return false;
+        }
+    }
+
+    /**
+     * 고유한 파일명 생성
+     */
+    private String generateFileName(String originalFileName) {
+        if (originalFileName == null) {
+            return UUID.randomUUID().toString();
+        }
+
+        String extension = "";
+        int lastDot = originalFileName.lastIndexOf('.');
+        if (lastDot > 0) {
+            extension = originalFileName.substring(lastDot);
+        }
+
+        return UUID.randomUUID() + extension;
+    }
+
+    /**
+     * S3 파일 URL 생성
+     */
+    private String generateFileUrl(String key) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                BUCKET_NAME, REGION, key);
+    }
+
+    /**
+     * S3 URL에서 키(key) 추출
+     */
+    private String extractKeyFromUrl(String fileUrl) {
+        try {
+            // https://bucket.s3.region.amazonaws.com/key 형태에서 key 부분 추출
+            String pattern = String.format("https://%s.s3.%s.amazonaws.com/",
+                    BUCKET_NAME, REGION);
+
+            if (fileUrl.startsWith(pattern)) {
+                return fileUrl.substring(pattern.length());
+            }
+
+            return null;
+        } catch (Exception e) {
+            log.error("URL에서 키 추출 실패: {}", fileUrl, e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/allinone/DevView/mypage/service/ProfileImageService.java
+++ b/src/main/java/com/allinone/DevView/mypage/service/ProfileImageService.java
@@ -1,5 +1,6 @@
 package com.allinone.DevView.mypage.service;
 
+import com.allinone.DevView.config.S3Service;
 import com.allinone.DevView.mypage.util.ImageFileUtils;
 import com.allinone.DevView.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +13,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.*;
 import java.util.Set;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -20,21 +20,25 @@ import java.util.UUID;
 public class ProfileImageService {
 
     private final UserRepository userRepository;
+    private final S3Service s3Service;
 
-    /** 애플리케이션 설정: 실제 저장 루트 (기본값: 실행 디렉터리 하위 "uploads") */
+    /** S3 사용 여부 플래그 */
+    @Value("${app.use-s3:true}")
+    private boolean useS3;
+
+    /** 기존 로컬 저장 설정 (백업용) */
     @Value("${app.upload-dir:uploads}")
-    private String uploadRoot; // 예) ${user.home}/devview_uploads
-
-    /** 웹에서 접근할 정적 URL 프리픽스 */
-    private static final String URL_PREFIX = "/uploads/profile/";
+    private String uploadRoot;
 
     /** 허용 확장자 & 사이즈(5MB) */
     private static final Set<String> ALLOWED_EXT = Set.of("jpg", "jpeg", "png", "webp");
     private static final long MAX_SIZE = 5L * 1024 * 1024;
 
     /**
-     * 프로필 이미지 업로드(파일시스템 저장만). User 엔티티 업데이트는 호출측(Service)에서 처리.
-     * @return 브라우저에서 접근 가능한 URL (예: /uploads/profile/{userId}/{filename})
+     * 프로필 이미지 업로드 (S3 또는 로컬)
+     * @param userId 사용자 ID
+     * @param imageFile 업로드할 이미지 파일
+     * @return 이미지 URL (S3 URL 또는 로컬 URL)
      */
     public String uploadProfileImage(Long userId, MultipartFile imageFile) {
         validateUser(userId);
@@ -46,7 +50,61 @@ public class ProfileImageService {
             throw new IllegalArgumentException("허용되지 않은 이미지 형식입니다. (jpg, jpeg, png, webp)");
         }
 
-        final String filename = UUID.randomUUID() + "." + ext;
+        if (useS3) {
+            return uploadToS3(userId, imageFile);
+        } else {
+            return uploadToLocal(userId, imageFile);
+        }
+    }
+
+    /**
+     * 프로필 이미지 삭제 (S3 또는 로컬)
+     * @param userId 사용자 ID
+     * @param imageUrl 삭제할 이미지 URL
+     */
+    public void deleteProfileImage(Long userId, String imageUrl) {
+        validateUser(userId);
+        if (imageUrl == null || imageUrl.isBlank()) {
+            return;
+        }
+
+        if (useS3 && isS3Url(imageUrl)) {
+            deleteFromS3(imageUrl);
+        } else {
+            deleteFromLocal(imageUrl);
+        }
+    }
+
+    /* ===================== S3 업로드/삭제 ===================== */
+
+    private String uploadToS3(Long userId, MultipartFile imageFile) {
+        try {
+            String folder = "profile/" + userId;
+            String s3Url = s3Service.uploadFile(imageFile, folder);
+            log.info("S3 업로드 성공 - 사용자: {}, URL: {}", userId, s3Url);
+            return s3Url;
+        } catch (Exception e) {
+            log.error("S3 업로드 실패 - 사용자: {}", userId, e);
+            throw new RuntimeException("프로필 이미지 업로드에 실패했습니다.", e);
+        }
+    }
+
+    private void deleteFromS3(String imageUrl) {
+        try {
+            s3Service.deleteFile(imageUrl);
+            log.info("S3 삭제 성공: {}", imageUrl);
+        } catch (Exception e) {
+            log.warn("S3 삭제 실패: {}", imageUrl, e);
+            throw new RuntimeException("프로필 이미지 삭제에 실패했습니다.", e);
+        }
+    }
+
+    /* ===================== 로컬 업로드/삭제 (기존 코드) ===================== */
+
+    private String uploadToLocal(Long userId, MultipartFile imageFile) {
+        final String originalName = imageFile.getOriginalFilename();
+        final String ext = ImageFileUtils.getFileExtension(originalName).toLowerCase();
+        final String filename = java.util.UUID.randomUUID() + "." + ext;
 
         // 실제 저장 경로 (파일시스템 절대경로): {uploadRoot}/profile/{userId}/{filename}
         final Path userDir = Paths.get(uploadRoot, "profile", String.valueOf(userId))
@@ -63,26 +121,17 @@ public class ProfileImageService {
                 Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
             }
 
-            log.debug("Saved profile image to {}", target);
+            log.debug("로컬 저장 성공: {}", target);
         } catch (IOException e) {
-            log.error("Failed to save profile image: {}", target, e);
+            log.error("로컬 저장 실패: {}", target, e);
             throw new RuntimeException("프로필 이미지 저장에 실패했습니다.", e);
         }
 
         // 반환 URL: /uploads/profile/{userId}/{filename}
-        return URL_PREFIX + userId + "/" + filename;
+        return "/uploads/profile/" + userId + "/" + filename;
     }
 
-    /**
-     * 파일 URL로 이미지 삭제 (파일 없으면 조용히 무시)
-     * 기대 URL: /uploads/profile/{userId}/{filename}
-     */
-    public void deleteProfileImage(Long userId, String imageUrl) {
-        validateUser(userId);
-        if (imageUrl == null || imageUrl.isBlank()) {
-            return;
-        }
-
+    private void deleteFromLocal(String imageUrl) {
         // URL → 로컬 파일 경로: {uploadRoot}/profile/{userId}/{filename}
         // "/uploads/" 프리픽스를 떼고 uploadRoot 밑으로 매핑
         final String url = imageUrl.startsWith("/") ? imageUrl.substring(1) : imageUrl; // uploads/profile/...
@@ -100,12 +149,19 @@ public class ProfileImageService {
                 try { Files.delete(parent); } catch (Exception ignore) { /* no-op */ }
             }
         } catch (IOException e) {
-            log.warn("Failed to delete profile image: {}", filePath, e);
+            log.warn("로컬 파일 삭제 실패: {}", filePath, e);
             throw new RuntimeException("프로필 이미지 삭제에 실패했습니다.", e);
         }
     }
 
-    /* ===================== 내부 유틸 ===================== */
+    /* ===================== 유틸리티 메서드 ===================== */
+
+    /**
+     * S3 URL인지 확인
+     */
+    private boolean isS3Url(String url) {
+        return url != null && url.contains("amazonaws.com");
+    }
 
     private void validateUser(Long userId) {
         userRepository.findById(userId)

--- a/src/main/java/com/allinone/DevView/ranking/service/RankingService.java
+++ b/src/main/java/com/allinone/DevView/ranking/service/RankingService.java
@@ -10,8 +10,6 @@ import com.allinone.DevView.user.entity.User;
 import com.allinone.DevView.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -187,10 +185,18 @@ public class RankingService {
         );
         Integer currentRank = usersAbove.intValue() + 1;
 
+        User user = ranking.getUser();
+
+        // 프로필 이미지 (UserProfile 연동)
+        String profileImageUrl = null;
+        if (user.getUserProfile() != null) {
+            profileImageUrl = user.getUserProfile().getProfileImageUrl();
+        }
+
         return RankingResponse.builder()
-                .userId(ranking.getUser().getUserId())
-                .username(ranking.getUser().getUsername())
-                .profileImageUrl("/img/profile-default.svg") // TODO: UserProfiles 연동시 실제 이미지로 변경
+                .userId(user.getUserId())
+                .username(user.getUsername())
+                .profileImageUrl(profileImageUrl != null ? profileImageUrl : "/img/profile-default.svg")
                 .rankingScore(ranking.getRankingScore())
                 .currentRank(currentRank)
                 .averageScore(ranking.getAverageScore())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,3 +107,19 @@ spring:
       hibernate:
         format_sql: false
         show_sql: false
+
+# AWS S3 설정
+aws:
+  credentials:
+    access-key: ${AWS_ACCESS_KEY_ID}
+    secret-key: ${AWS_SECRET_ACCESS_KEY}
+  s3:
+    bucket: devview-allinone
+    region: ap-northeast-2  # 서울 리전
+  region:
+    static: ap-northeast-2
+
+# 앱 설정
+app:
+  upload-dir: uploads  # 기존 설정 유지 (백업용)
+  use-s3: true  # S3 사용 여부 플래그

--- a/src/main/resources/templates/ranking/ranking.html
+++ b/src/main/resources/templates/ranking/ranking.html
@@ -43,9 +43,9 @@
                     <div th:if="${iterStat.index == 1}" class="medal">🥈</div>
                     <div th:if="${iterStat.index == 2}" class="medal">🥉</div>
 
-                    <img th:src="${ranking.profileImageUrl}"
+                    <img class="profile-image"
+                         th:src="${ranking.profileImageUrl != null} ? @{${ranking.profileImageUrl}} : '/img/진욱.svg'"
                          th:alt="${ranking.username} + ' 프로필'"
-                         class="profile-image"
                          onerror="this.src='/img/profile-default.svg'">
                 </div>
 
@@ -82,9 +82,9 @@
                     th:text="${iterStat.index + 1}">1</td>
 
                 <td class="user-info">
-                    <img th:src="${ranking.profileImageUrl}"
+                    <img class="table-profile-img"
+                         th:src="${ranking.profileImageUrl != null} ? @{${ranking.profileImageUrl}} : '/img/진욱.svg'"
                          th:alt="${ranking.username} + ' 프로필'"
-                         class="table-profile-img"
                          onerror="this.src='/img/profile-default.svg'">
                     <span class="user-name" th:text="${ranking.username}">유저1</span>
                 </td>


### PR DESCRIPTION
- S3Config, S3Service 추가하여 AWS S3 파일 업로드/삭제 지원
- ProfileImageService 업데이트: 환경 설정에 따라 S3 또는 로컬 저장 지원
- RankingService 및 ranking.html에서 실제 UserProfile 이미지 URL 사용
- application.yml에 S3 및 앱 설정 추가, pom.xml에 AWS SDK 의존성 추가
- 기존 디폴트 이미지 대신 유저 프로필 이미지 노출 개선